### PR TITLE
[PPML] turn keywhiz client from CLI to native methods

### DIFF
--- a/ppml/services/bigdl-kms/docker/Dockerfile
+++ b/ppml/services/bigdl-kms/docker/Dockerfile
@@ -97,6 +97,7 @@ RUN cd keywhiz && \
     cp docker/wizard.sh /usr/src/app && \
     cp docker/keywhiz-config.tpl /usr/src/app && \
     cp frontend-keywhiz-conf.yaml /usr/src/app && \
+    cp /usr/src/app/server/src/main/resources/dev_and_test_keystore.p12 /usr/src/app/cli/src/main/resources/dev_and_test_keystore.p12 && \
     chmod a+x /usr/src/app/entry.sh
 ADD ./start-https-frontend.sh /usr/src/app/start-https-frontend.sh
 RUN chmod a+x /usr/src/app/start-https-frontend.sh && \

--- a/ppml/services/bigdl-kms/docker/start-https-frontend.sh
+++ b/ppml/services/bigdl-kms/docker/start-https-frontend.sh
@@ -24,6 +24,8 @@ echo "[INFO] Launching BigDL KMS HTTPS Frontend"
 keywhiz_port=$KEYWHIZ_PORT
 https_key_store_path=/usr/src/app/server/src/main/resources/dev_and_test_keystore.p12
 https_secure_password=$HTTPS_SECURE_PASSWORD # k8s secret
+keywhiz_cli_jar_path=/usr/src/app/cli/target/keywhiz-cli-0.10.2-SNAPSHOT-shaded.jar
+key_provider_jar_path=/usr/src/app/server/target/keywhiz-server-0.10.2-SNAPSHOT-shaded.jar
 
 java \
     -Xms2g \
@@ -37,5 +39,8 @@ java \
     -cp "$BIGDL_HOME/jars/*" \
     com.intel.analytics.bigdl.ppml.kms.frontend.BigDLKMSFrontend \
     --keywhizHost "keywhiz-service" \
+    --keywhizPort ${keywhiz_port} \
     --httpsKeyStorePath "${https_key_store_path}" \
-    --httpsKeyStoreToken "${https_secure_password}" | tee ./bkeywhiz-https-frontend.log
+    --httpsKeyStoreToken "${https_secure_password}" \
+    --keywhizCliJarPath "${keywhiz_cli_jar_path}" \
+    --keyProviderJarPath "${key_provider_jar_path}" | tee ./bkeywhiz-https-frontend.log


### PR DESCRIPTION
## Description

BigDL KMS Frontend used to communicate keywhiz server through keywhiz CLI (calling jars in java CLI), and this causes an inability to run BigDL KMS in SGX environment since such a process creates many JVM process that leads to high overhead for SGX execution. Also, the JVM creations make the request latency larger and therefore worsen QoE.

As a result, we turn from CLI to directly calling native methods in external keywhiz jars by applying reflection as a solution. 

### 1. Why the change?

As above.

### 2. User API changes

None.

### 3. Summary of the change 

Turn keywhiz client from CLI to native methods in BigDL KMS Frontend.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
