### PR TITLE
[PPML] azure blob support in spark

### DIFF
--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -342,6 +342,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+	<dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.azure</groupId>
 	    <artifactId>azure-identity</artifactId>

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
@@ -120,6 +120,10 @@ class PPMLContext {
       write(boosterDF, cryptoMode, primaryKeyName).text(path)
   }
 
+  def setHadoopConf(key: String, value: String): this.type = {
+    sparkSession.sparkContext.hadoopConfiguration.set(key, value)
+  }
+
   /**
    * Interface for loading data in external storage to Dataset.
    * @param cryptoMode crypto mode, such as PLAIN_TEXT or AES_CBC_PKCS5PADDING


### PR DESCRIPTION
## Description

add an interface in PPMLContext to set hadoop configuration, which can support low-level operation like azure blob storage access, while pls note that we just a provide a flexible interface for users to set confs as we needed, and do not assure about the original work mechanism of any configuration, as it is in scope of the low-level frameworks like hadoop or azure

### 1. Why the change?

some conf only works when set in hadoopConfiguration rather than sparkConf

### 2. User API changes

Users can set conf to hadoop like below:
```scala
val sc = PPMLContext.init(...)
sc.setHadoopConf("<key>", "<value>")
```

### 3. Summary of the change 

as above

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

com.azure:azure-storage-blob