### PR TITLE
[LLM] support quantize ipex transformers

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert_ipex_transformers.py
+++ b/python/llm/src/bigdl/llm/transformers/convert_ipex_transformers.py
@@ -1,0 +1,96 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Some parts of this file is adapted from
+# https://github.com/huggingface/transformers/blob/v4.30.2/src/transformers/utils/bitsandbytes.py
+# and https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py
+# which is licensed under Apache License 2.0:
+#
+# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import torch.nn as nn
+from accelerate import init_empty_weights
+
+from bigdl.llm.utils.common.log4Error import invalidInputError
+from bigdl.llm.transformers.linear_quant import LinearQuant, ParamsQuant
+
+from intel_extension_for_pytorch.nn.utils._transformers import IPEXEmptyLinear
+
+def _convert_ipex_transformers(model: nn.Module):
+    for name, module in model.named_children():
+        if isinstance(module, nn.Linear) or isinstance(module, IPEXEmptyLinear) and module.weight is not None:
+            with init_empty_weights():
+                # create new quantized linear
+                if isinstance(module, nn.Linear):
+                    new_linear = LinearQuant(
+                        module.in_features,
+                        module.out_features,
+                        2,
+                        module.bias is not None,
+                    )
+                else:
+                    # "out_proj" in Llama cannot be converted to int4
+                    if "out_proj" in name:
+                        continue
+
+                    new_linear = LinearQuant(
+                        module.weight.data.shape[1],
+                        module.weight.data.shape[0],
+                        2,
+                        module.bias is not None,
+                    )
+                # copy weights and bias
+                paramsQuant = ParamsQuant(data=module.weight.data,
+                                          requires_grad=False,
+                                          quantized=False,
+                                          qtype=2).to("cpu")
+                new_linear._parameters['weight'] = paramsQuant.to("xpu")
+                new_linear._parameters['bias'] = module.bias
+                module.weight = None
+                module.bias = None
+
+                # replace linear
+                model._modules[name] = new_linear
+                model._modules[name].requires_grad_(False)
+        elif len(list(module.children())) > 0:
+            _convert_ipex_transformers(module)
+
+    return model
+
+
+def convert_ipex_transformers(model: nn.Module, qtype: int = 2):
+    from transformers import LlamaForCausalLM
+    invalidInputError(isinstance(model, LlamaForCausalLM),
+                      "Now only `LlamaForCausalLM` is supported.")
+    invalidInputError(qtype == 2,
+                      "Now only q4_0(qtype=2) is supported.")
+    col_major = os.environ.get("COL_MAJOR", "OFF").upper()in ["1", "Y", "ON", "YES", "TRUE"]
+    invalidInputError(col_major, 'Now only col_major mode is supported. (export COL_MAJOR=1)')
+    return _convert_ipex_transformers(model)

--- a/python/llm/src/bigdl/llm/transformers/convert_ipex_transformers.py
+++ b/python/llm/src/bigdl/llm/transformers/convert_ipex_transformers.py
@@ -43,9 +43,10 @@ from bigdl.llm.transformers.linear_quant import LinearQuant, ParamsQuant
 
 from intel_extension_for_pytorch.nn.utils._transformers import IPEXEmptyLinear
 
+
 def _convert_ipex_transformers(model: nn.Module):
     for name, module in model.named_children():
-        if isinstance(module, nn.Linear) or isinstance(module, IPEXEmptyLinear) and module.weight is not None:
+        if isinstance(module, (nn.Linear, IPEXEmptyLinear)):
             with init_empty_weights():
                 # create new quantized linear
                 if isinstance(module, nn.Linear):
@@ -57,7 +58,7 @@ def _convert_ipex_transformers(model: nn.Module):
                     )
                 else:
                     # "out_proj" in Llama cannot be converted to int4
-                    if "out_proj" in name:
+                    if "out_proj" in name or module.weight is None:
                         continue
 
                     new_linear = LinearQuant(


### PR DESCRIPTION
## Description

**This is only an internal API** to quantize ipex transformers model to int4

### 1. User API

```python
from transformers import LlamaForCausalLM, LlamaTokenizer
import intel_extension_for_pytorch as ipex

device = 'xpu'
amp_dtype = 'float16'
prompt = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
model_dir = ''

# load model in fp16 precision
model = LlamaForCausalLM.from_pretrained(model_dir, low_cpu_mem_usage=True, torch_dtype=amp_dtype)
tokenizer = LlamaTokenizer.from_pretrained(model_dir)

# move model to xpu
model = model.eval().to(device)

# call ipex.optimize_transformers
model = ipex.optimize_transformers(model, dtype=amp_dtype)

# quantize to int4
from bigdl.llm.transformers.convert_ipex_transformers import convert_ipex_transformers
model = convert_ipex_transformers(model)

# inference
with torch.inference_mode(), torch.autocast(device_type=device, dtype=amp_dtype):
    input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to(device)
    output = model.generate(input_ids, max_new_tokens=32, do_sample=False, temperature=0.9)
    ...
```

**Note: Set the following environment variables before running this code:**
```bash
export USE_XETLA=OFF
export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 ENABLE_SDP_FUSION=1
export COL_MAJOR=1
export ENABLE_SDP_FUSION=0
```

**Note: Now only Llama and q4_0 are supported**

**Note: open-llama-3b peak GPU memory usage is about 9900 MB, cannot run llama-7b**

Some performance of open-llama-3b with 32in/32out:

  | 1st token latency(ms) | 2nd+ token latency(ms)
-- | -- | --
ipex fp16 | 34 | 35
ipex fp16+transformer int4 | 118 | 26
transformer int4 | 140 | 31.5
