### PR TITLE
[WIP] Avoid coverting model to FP32 during model optimization

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -190,7 +190,8 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
                 f"{list(ggml_tensor_qtype.keys())[list(ggml_tensor_qtype.values()).index(qtype)]} "
                 f"format......")
     modules_to_not_convert = [] if modules_to_not_convert is None else modules_to_not_convert
-
+    # Preserve previous model type
+    raw_model_type = model.dtype
     if optimize_model:
         model = _optimize_pre(model)
 
@@ -213,6 +214,9 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
 
     if optimize_model:
         model = _optimize_post(model)
+    # Cover model back to previous model type
+    if device == "cpu":
+        model.to(raw_model_type)
     return model
 
 

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -214,7 +214,7 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
 
     if optimize_model:
         model = _optimize_post(model)
-    # Cover model back to previous model type
+    # Convert model back to previous model type
     if device == "cpu":
         model.to(raw_model_type)
     return model

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -477,6 +477,8 @@ class LowBitLinear(nn.Linear):
                     result = result.view(new_shape)
                     if self.bias is not None:
                         result += self.bias
+        # Convert back to autocast or x.dtype
+        # to avoid casting attention to FP32
         if x.dtype != result.dtype:
             if torch.is_autocast_enabled:
                 result = result.to(torch.get_autocast_dtype)

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -478,7 +478,10 @@ class LowBitLinear(nn.Linear):
                     if self.bias is not None:
                         result += self.bias
         if x.dtype != result.dtype:
-            result = result.to(x.dtype)
+            if torch.is_autocast_enabled:
+                result = result.to(torch.get_autocast_dtype)
+            else:
+                result = result.to(x.dtype)
         return result
 
 

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -480,8 +480,8 @@ class LowBitLinear(nn.Linear):
         # Convert back to autocast or x.dtype
         # to avoid casting attention to FP32
         if x.dtype != result.dtype:
-            if torch.is_autocast_enabled:
-                result = result.to(torch.get_autocast_dtype)
+            if torch.is_autocast_enabled():
+                result = result.to(torch.get_autocast_dtype())
             else:
                 result = result.to(x.dtype)
         return result

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -477,6 +477,8 @@ class LowBitLinear(nn.Linear):
                     result = result.view(new_shape)
                     if self.bias is not None:
                         result += self.bias
+        if x.dtype != result.dtype:
+            result = result.to(x.dtype)
         return result
 
 

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -214,8 +214,9 @@ def llama_attention_forward_4_31(
         attn_weights = attn_weights + attention_mask
 
     # upcast attention to fp32
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1,
-                                         dtype=attn_weights.dtype).to(query_states.dtype)
+    # attn_weights = nn.functional.softmax(attn_weights, dim=-1,
+    #                                      dtype=torch.float32).to(query_states.dtype)
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1)
     attn_output = torch.matmul(attn_weights, value_states)
 
     attn_output_size = (bsz, self.num_heads, q_len, self.head_dim)

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -215,7 +215,7 @@ def llama_attention_forward_4_31(
 
     # upcast attention to fp32
     attn_weights = nn.functional.softmax(attn_weights, dim=-1,
-                                         dtype=torch.float32).to(query_states.dtype)
+                                         dtype=attn_weights.dtype).to(query_states.dtype)
     attn_output = torch.matmul(attn_weights, value_states)
 
     attn_output_size = (bsz, self.num_heads, q_len, self.head_dim)

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -214,9 +214,8 @@ def llama_attention_forward_4_31(
         attn_weights = attn_weights + attention_mask
 
     # upcast attention to fp32
-    # attn_weights = nn.functional.softmax(attn_weights, dim=-1,
-    #                                      dtype=torch.float32).to(query_states.dtype)
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1,
+                                         dtype=torch.float32).to(query_states.dtype)
     attn_output = torch.matmul(attn_weights, value_states)
 
     attn_output_size = (bsz, self.num_heads, q_len, self.head_dim)


### PR DESCRIPTION
## Description
Avoiding converting model into FP32 during model optimization.

This PR ensure some low-precision or half precision layers will not be impacted by transformer optimization. For example, attention layers in Llama-2 will kept BF16 after optimization if they are already BF16. It will reduce latency and memory usage for these attention layers. 

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
