### PR TITLE
Fix internlm-chat-7b-8k repo name 

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm/README.md
@@ -50,7 +50,7 @@ numactl -C 0-47 -m 0 python ./generate.py
 ```
 
 #### 2.3 Sample Output
-#### [internlm/internlm-chat-7b-8k](https://huggingface.co/internlm/internlm-chat-7b-8k)
+#### [internlm/internlm-chat-7b-8k](https://huggingface.co/internlm/internlm-chat-7b)
 ```log
 Inference time: xxxx s
 -------------------- Prompt --------------------

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm/generate.py
@@ -23,12 +23,12 @@ from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b-8k/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for InternLM model')
-    parser.add_argument('--repo-id-or-model-path', type=str, default="internlm/internlm-chat-7b-8k",
+    parser.add_argument('--repo-id-or-model-path', type=str, default="internlm/internlm-chat-7b",
                         help='The huggingface repo id for the InternLM model to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
     parser.add_argument('--prompt', type=str, default="AI是什么？",

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
@@ -22,7 +22,7 @@ import numpy as np
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b-8k/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
@@ -22,7 +22,7 @@ import numpy as np
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/CPU/PyTorch-Models/Model/internlm2/generate.py
+++ b/python/llm/example/CPU/PyTorch-Models/Model/internlm2/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm import optimize_model
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b-8k/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/CPU/PyTorch-Models/Model/internlm2/generate.py
+++ b/python/llm/example/CPU/PyTorch-Models/Model/internlm2/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm import optimize_model
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm/README.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm/README.md
@@ -105,7 +105,7 @@ Arguments info:
 - `--n-predict N_PREDICT`: argument defining the max number of tokens to predict. It is default to be `32`.
 
 #### Sample Output
-#### [internlm/internlm-chat-7b-8k](https://huggingface.co/internlm/internlm-chat-7b-8k)
+#### [internlm/internlm-chat-7b](https://huggingface.co/internlm/internlm-chat-7b)
 ```log
 Inference time: xxxx s
 -------------------- Prompt --------------------

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm/generate.py
@@ -22,12 +22,12 @@ from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b-8k/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for InternLM model')
-    parser.add_argument('--repo-id-or-model-path', type=str, default="internlm/internlm-chat-7b-8k",
+    parser.add_argument('--repo-id-or-model-path', type=str, default="internlm/internlm-chat-7b",
                         help='The huggingface repo id for the InternLM model to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
     parser.add_argument('--prompt', type=str, default="AI是什么？",

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm import optimize_model
 import intel_extension_for_pytorch as ipex
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b-8k/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm import optimize_model
 import intel_extension_for_pytorch as ipex
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/GPU/PyTorch-Models/Model/internlm2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/internlm2/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm import optimize_model
 import intel_extension_for_pytorch as ipex
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b-8k/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/example/GPU/PyTorch-Models/Model/internlm2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/internlm2/generate.py
@@ -23,7 +23,7 @@ from bigdl.llm import optimize_model
 import intel_extension_for_pytorch as ipex
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L768
+# here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053
 INTERNLM_PROMPT_FORMAT = "<|User|>:{prompt}\n<|Bot|>:"
 
 if __name__ == '__main__':

--- a/python/llm/portable-zip/README.md
+++ b/python/llm/portable-zip/README.md
@@ -15,7 +15,7 @@ This portable zip includes everything you need to run an LLM with BigDL-LLM opti
 - ChatGLM2-6b
 - Baichuan-13B-Chat
 - Baichuan2-7B-Chat
-- internlm-chat-7b-8k
+- internlm-chat-7b
 - Llama-2-7b-chat-hf
 
 ## How to use


### PR DESCRIPTION
The repo "internlm/internlm-chat-7b-8k" does not exist now. So do the corresponding changes from "internlm/internlm-chat-7b-8k" to "internlm/internlm-chat-7b".

Verify the gpu/cpu examples of repo "internlm/internlm-chat-7b".
