### PR TITLE
[bigdl-llm langchain api]Add cpu_embedding and its ut

### DIFF
--- a/python/llm/src/bigdl/llm/langchain/llms/transformersllm.py
+++ b/python/llm/src/bigdl/llm/langchain/llms/transformersllm.py
@@ -90,6 +90,7 @@ class TransformersLLM(LLM):
         model_id: str,
         model_kwargs: Optional[dict] = None,
         device_map: str = 'cpu',
+        cpu_embedding: bool = False, 
         **kwargs: Any,
     ) -> LLM:
         """
@@ -118,6 +119,8 @@ class TransformersLLM(LLM):
                 "Could not import transformers python package. "
                 "Please install it with `pip install transformers`."
             )
+        
+        model_kwargs['cpu_embedding'] = cpu_embedding
 
         _model_kwargs = model_kwargs or {}
         # TODO: may refactore this code in the future

--- a/python/llm/test/langchain_gpu/test_transformers_api.py
+++ b/python/llm/test/langchain_gpu/test_transformers_api.py
@@ -43,6 +43,15 @@ class Test_Langchain_Transformers_API(TestCase):
         output = bigdl_llm(texts)
         res = "Paris" in output
         self.assertTrue(res)
+    
+    def test_cpu_embedding(self):
+        texts = 'What is the capital of France?\n\n'
+        bigdl_llm = TransformersLLM.from_model_id(model_id=self.llama_model_path, 
+                                                  model_kwargs={'trust_remote_code': True}, device_map=device, cpu_embedding=True)
+        
+        output = bigdl_llm(texts)
+        res = "Paris" in output
+        self.assertTrue(res)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
## Description

In python/llm/src/bigdl/llm/langchain/llms/transformersllm.py and python/llm/test/langchain_gpu/test_transformers_api.py, add cpu_embedding and its unit test.