### PR TITLE
LLM: Reorg BigDL-LLM Document page based on current contents

### DIFF
--- a/docs/readthedocs/source/_templates/sidebar_quicklinks.html
+++ b/docs/readthedocs/source/_templates/sidebar_quicklinks.html
@@ -10,10 +10,10 @@
                 </label>
                 <ul class="nav bigdl-quicklinks-section-nav">
                     <li>
-                        <a href="doc/LLM/Quickstart/install_windows_gpu.html">Install BigDL-LLM on Windows with Intel GPU</a>
+                        <a href="doc/LLM/Quickstart/install_windows_gpu.html">Install BigDL-LLM on Windows</a>
                     </li>
                     <li>
-                        <a href="doc/LLM/Quickstart/webui_quickstart.html">Use Text Generation WebUI on Windows with Intel GPU</a>
+                        <a href="doc/LLM/Quickstart/webui_quickstart.html">Use Text Generation WebUI on Windows</a>
                     </li>
                     <li>
                         <a href="doc/LLM/Quickstart/benchmark_quickstart.html">BigDL-LLM Benchmarking</a>

--- a/docs/readthedocs/source/_toc.yml
+++ b/docs/readthedocs/source/_toc.yml
@@ -24,8 +24,8 @@ subtrees:
       title: "LLM"
       subtrees:
         - entries:
-          - file: doc/LLM/Overview/llm
-            title: "LLM in 5 minutes"
+          # - file: doc/LLM/Overview/llm
+          #   title: "LLM in 5 minutes"
           - file: doc/LLM/Overview/install
             title: "Installation"
             subtrees:
@@ -47,10 +47,10 @@ subtrees:
               - entries:
                 - file: doc/LLM/Overview/KeyFeatures/optimize_model
                 - file: doc/LLM/Overview/KeyFeatures/transformers_style_api
-                  subtrees:
-                    - entries:
-                      - file: doc/LLM/Overview/KeyFeatures/hugging_face_format
-                      - file: doc/LLM/Overview/KeyFeatures/native_format
+                - file: doc/LLM/Overview/KeyFeatures/hugging_face_format
+                  # subtrees:
+                  #   - entries:
+                  #     - file: doc/LLM/Overview/KeyFeatures/native_format
                 - file: doc/LLM/Overview/KeyFeatures/langchain_api
                 # - file: doc/LLM/Overview/KeyFeatures/cli
                 - file: doc/LLM/Overview/KeyFeatures/gpu_supports
@@ -59,14 +59,14 @@ subtrees:
                       - file: doc/LLM/Overview/KeyFeatures/inference_on_gpu
                       - file: doc/LLM/Overview/KeyFeatures/finetune
                       - file: doc/LLM/Overview/KeyFeatures/multi_gpus_selection
-          - file: doc/LLM/Overview/examples
-            title: "Examples"
-            subtrees:
-              - entries:
-                - file: doc/LLM/Overview/examples_cpu
-                  title: "CPU"
-                - file: doc/LLM/Overview/examples_gpu
-                  title: "GPU"
+          # - file: doc/LLM/Overview/examples
+          #   title: "Examples"
+          #   subtrees:
+          #     - entries:
+          #       - file: doc/LLM/Overview/examples_cpu
+          #         title: "CPU"
+          #       - file: doc/LLM/Overview/examples_gpu
+          #         title: "GPU"
           # - file: doc/LLM/Overview/known_issues
           #   title: "Tips and Known Issues"
           - file: doc/PythonAPI/LLM/index

--- a/docs/readthedocs/source/_toc.yml
+++ b/docs/readthedocs/source/_toc.yml
@@ -46,7 +46,7 @@ subtrees:
             subtrees:
               - entries:
                 - file: doc/LLM/Overview/KeyFeatures/optimize_model
-                - file: doc/LLM/Overview/KeyFeatures/transformers_style_api
+                # - file: doc/LLM/Overview/KeyFeatures/transformers_style_api
                 - file: doc/LLM/Overview/KeyFeatures/hugging_face_format
                   # subtrees:
                   #   - entries:

--- a/docs/readthedocs/source/doc/LLM/Overview/KeyFeatures/index.rst
+++ b/docs/readthedocs/source/doc/LLM/Overview/KeyFeatures/index.rst
@@ -4,10 +4,10 @@ BigDL-LLM Key Features
 You may run the LLMs using ``bigdl-llm`` through one of the following APIs:
 
 * `PyTorch API <./optimize_model.html>`_
-* |transformers_style_api|_
+.. * |transformers_style_api|_
 
-  * |hugging_face_transformers_format|_
-  * `Native Format <./native_format.html>`_
+* |hugging_face_transformers_format|_
+  .. * `Native Format <./native_format.html>`_
 
 * `LangChain API <./langchain_api.html>`_
 * |gpu_supports|_

--- a/docs/readthedocs/source/doc/LLM/Quickstart/install_windows_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/install_windows_gpu.md
@@ -1,4 +1,4 @@
-# Install BigDL-LLM on Windows with Intel GPU
+# Install BigDL-LLM on Windows
 
 This guide demonstrates how to install BigDL-LLM on Windows with Intel GPUs. 
 

--- a/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
@@ -1,5 +1,5 @@
 
-# Use Text Generation WebUI on Windows with Intel GPU
+# Use Text Generation WebUI on Windows
 
 This quickstart guide walks you through setting up and using the [Text Generation WebUI](https://github.com/intel-analytics/text-generation-webui) (a Gradio WebUI for running Large Language Models) with `bigdl-llm`. 
 

--- a/docs/readthedocs/source/doc/LLM/index.rst
+++ b/docs/readthedocs/source/doc/LLM/index.rst
@@ -20,7 +20,7 @@ BigDL-LLM
         Documents in these sections helps you getting started quickly with BigDL-LLM.
 
         +++
-        :bdg-link:`BigDL-LLM in 5 minutes <./Overview/llm.html>` |
+        :bdg-link:`Quickstart <./Quickstart/index.html>` |
         :bdg-link:`Installation <./Overview/install.html>`
 
     .. grid-item-card::
@@ -33,7 +33,7 @@ BigDL-LLM
         +++
 
         :bdg-link:`PyTorch <./Overview/KeyFeatures/optimize_model.html>` |
-        :bdg-link:`transformers-style <./Overview/KeyFeatures/transformers_style_api.html>` |
+        :bdg-link:`Hugging Face transformers Format <./Overview/KeyFeatures/hugging_face_format.html>` |
         :bdg-link:`LangChain <./Overview/KeyFeatures/langchain_api.html>` |
         :bdg-link:`GPU <./Overview/KeyFeatures/gpu_supports.html>`
 
@@ -46,7 +46,8 @@ BigDL-LLM
 
         +++
 
-        :bdg-link:`Examples <./Overview/examples.html>`
+        :bdg-link:`Examples <./Overview/examples.html>` |
+        :bdg-link:`Tutorials <https://github.com/intel-analytics/bigdl-llm-tutorial>`
 
     .. grid-item-card::
 

--- a/docs/readthedocs/source/doc/LLM/index.rst
+++ b/docs/readthedocs/source/doc/LLM/index.rst
@@ -33,7 +33,7 @@ BigDL-LLM
         +++
 
         :bdg-link:`PyTorch <./Overview/KeyFeatures/optimize_model.html>` |
-        :bdg-link:`Hugging Face transformers Format <./Overview/KeyFeatures/hugging_face_format.html>` |
+        :bdg-link:`transformers <./Overview/KeyFeatures/hugging_face_format.html>` |
         :bdg-link:`LangChain <./Overview/KeyFeatures/langchain_api.html>` |
         :bdg-link:`GPU <./Overview/KeyFeatures/gpu_supports.html>`
 
@@ -46,7 +46,7 @@ BigDL-LLM
 
         +++
 
-        :bdg-link:`Examples <./Overview/examples.html>` |
+        :bdg-link:`Examples <https://github.com/intel-analytics/BigDL/tree/main/python/llm/example>` |
         :bdg-link:`Tutorials <https://github.com/intel-analytics/bigdl-llm-tutorial>`
 
     .. grid-item-card::


### PR DESCRIPTION
- Reorg BigDL-LLM Document page based on current contents
- Hide some pages:
  - LLM in 5 minutes
  - Key Features->transformers-style API -> Native Format
  - Examples
- Make title of [Install BigDL-LLM on Windows with Intel GPU](https://bigdl.readthedocs.io/en/latest/doc/LLM/Quickstart/install_windows_gpu.html)
[Use Text Generation WebUI on Windows with Intel GPU](https://bigdl.readthedocs.io/en/latest/doc/LLM/Quickstart/webui_quickstart.html) shorter