### PR TITLE
LLM: fix mistral hidden_size setting for deepspeed autotp

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/mistral.py
+++ b/python/llm/src/ipex_llm/transformers/models/mistral.py
@@ -482,7 +482,7 @@ def mistral_attention_forward_original(
                                                      is_causal=True)
         attn_weights = None
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(bsz, q_len, hidden_size)
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
     elif use_esimd_sdp(q_len, key_states.shape[2], self.head_dim, query_states):
         import linear_fp16_esimd
         attn_output = linear_fp16_esimd.sdp_forward(query_states,
@@ -491,7 +491,7 @@ def mistral_attention_forward_original(
         attn_output = attn_output.view(query_states.shape)
         attn_weights = None
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(bsz, q_len, hidden_size)
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
     else:
         attn_output, attn_weights = compute_attn_outputs_weights(query_states,
                                                                  key_states,
@@ -854,7 +854,7 @@ def mistral_attention_forward_4_36_original(
                                                      is_causal=True)
         attn_weights = None
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(bsz, q_len, hidden_size)
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
     else:
         attn_output, attn_weights = compute_attn_outputs_weights(query_states,
                                                                  key_states,


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Background: https://github.com/intel-analytics/ipex-llm/issues/10507
When run mistral/neural-chat inference with Deepspeed AutoTP, tensor shape error is caused by wrong `hidden_size`

This PR fixes following error:
<img width="1441" alt="image" src="https://github.com/intel-analytics/ipex-llm/assets/108676127/63e63826-97bb-4887-abc4-e030d763de4c">

### 4. How to test?
- [ ] Unit test
- [x] Local test (single and two ARC inference)