### PR TITLE
LLM: Add length check for IPEX-CPU speculative decoding 

### DIFF
--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -64,6 +64,7 @@ def generate(
                         'auto_th_stop_draft', 'auto_parameters', 'min_step_draft',
                         'th_batch_num']:
                 value = kwargs.pop(var, None)
+            del self.draft_model
             return original_generate(self,
                                      inputs=inputs,
                                      generation_config=generation_config,

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -57,7 +57,7 @@ def generate(
         _enable_ipex = get_enable_ipex()
         if _enable_ipex and inputs.size(1) < 256:
             logger.warning(
-                "IPEX optimized models have issues for speculative decoding with short prompts"
+                "IPEX_CPU optimized models have issues for speculative decoding with short prompts"
                 "(length < 256). Using normal generate() method instead."
             )
             for var in ['max_step_draft', 'th_stop_draft', 'hf_adjust',


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Add length check for IPEX-CPU speculative decoding. For length < 256 prompts will use original_generate() method.