### PR TITLE
fix chatglm

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/chatglm2.py
+++ b/python/llm/src/ipex_llm/transformers/models/chatglm2.py
@@ -184,7 +184,7 @@ def chatglm2_model_forward(
 def chatglm2_attention_forward(
     self, hidden_states, attention_mask, rotary_pos_emb, kv_cache=None, use_cache=True
 ):
-    if use_quantize_kv_cache(self.query_key_value, hidden_states):
+    if use_quantize_kv_cache(self.query_key_value, hidden_states.transpose(0, 1)):
         forward_function = chatglm2_quantized_attention_forward_8eb45c
     else:
         forward_function = chatglm2_attention_forward_8eb45c


### PR DESCRIPTION
## Description

The shape of chatglm's hidden_states is `[seq_len, batch_size, hidden_size]`, which is different from other models' `[batch_size, seq_len, hidden_size]`.

When `2 <= seq_len <= 8`, it will use quantize kv in first token, and not use quantize kv in rest token, which causes this error, so fix it.

https://github.com/intel-analytics/ipex-llm/issues/10515