### PR TITLE
support fp8 in xetla

### DIFF
--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -452,6 +452,8 @@ class FP4Params(torch.nn.Parameter):
                                   enable_xetla=self.enable_xetla)
             if self.enable_xetla:
                 ggml_xpu = ipex_llm_xetla_to_ggml_xpu(new_param.data, new_param._shape, new_param.qtype)
+            else:
+                ggml_xpu = new_param.data
             new_param.data = ggml_q_format_convet_xpu2cpu(ggml_xpu,
                                                           reduce(mul, new_param._shape, 1),
                                                           new_param.qtype)

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -75,6 +75,7 @@ IQ2_XS = ggml_tensor_qtype["gguf_iq2_xs"]
 Q2_K = ggml_tensor_qtype["q2_k"]
 IQ1_S = ggml_tensor_qtype["gguf_iq1_s"]
 
+
 # For sym_int4
 # The ggml_weight is col major and packs two rows at a stride of Q4_0//2.
 #
@@ -132,6 +133,7 @@ def ggml_xpu_to_ipex_llm_xetla(ggml_weight, weight_shape, qtype):
     else:
         invalidInputError(False, f"Unsupported qtype {qtype}")
     return weight
+
 
 def ipex_llm_xetla_to_ggml_xpu(xetla_weight, weight_shape, qtype):
     from ipex_llm.transformers.low_bit_linear import get_block_size
@@ -451,7 +453,9 @@ class FP4Params(torch.nn.Parameter):
                                   qtype=self.qtype,
                                   enable_xetla=self.enable_xetla)
             if self.enable_xetla:
-                ggml_xpu = ipex_llm_xetla_to_ggml_xpu(new_param.data, new_param._shape, new_param.qtype)
+                ggml_xpu = ipex_llm_xetla_to_ggml_xpu(new_param.data,
+                                                      new_param._shape,
+                                                      new_param.qtype)
             else:
                 ggml_xpu = new_param.data
             new_param.data = ggml_q_format_convet_xpu2cpu(ggml_xpu,

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -298,7 +298,7 @@ def fuse_qkv_weight(q_proj, k_proj, v_proj):
     return torch.cat([qweight, qzeros, qscales], dim=0)
 
 
-def should_use_mm_int4_qkv(self, device):
+def should_use_mm_xetla_qkv(self, device):
     return device.type == "xpu" and self.q_proj.qtype == SYM_INT4 and self.q_proj.enable_xetla
 
 
@@ -553,13 +553,13 @@ def llama_attention_forward_4_31_original(
                     query_states, key_states, value_states
                 )
             else:
-                if should_use_mm_int4_qkv(self, device):
+                if should_use_mm_xetla_qkv(self, device):
                     if not hasattr(self, "qkv_proj_qweight"):
                         self.qkv_proj_qweight = fuse_qkv_weight(self.q_proj,
                                                                 self.k_proj,
                                                                 self.v_proj)
                     import linear_q4_0
-                    qkv_states = linear_q4_0.mm_int4(hidden_states, self.qkv_proj_qweight)
+                    qkv_states = linear_q4_0.mm_xetla(hidden_states, self.qkv_proj_qweight)
                     query_states = qkv_states[:, :, :hidden_size]
                     key_states = qkv_states[:, :, hidden_size:2*hidden_size]
                     value_states = qkv_states[:, :, 2*hidden_size:]
@@ -1196,13 +1196,13 @@ def llama_attention_forward_4_36_original(
                     query_states, key_states, value_states
                 )
             else:
-                if should_use_mm_int4_qkv(self, device):
+                if should_use_mm_xetla_qkv(self, device):
                     if not hasattr(self, "qkv_proj_qweight"):
                         self.qkv_proj_qweight = fuse_qkv_weight(self.q_proj,
                                                                 self.k_proj,
                                                                 self.v_proj)
                     import linear_q4_0
-                    qkv_states = linear_q4_0.mm_int4(hidden_states, self.qkv_proj_qweight)
+                    qkv_states = linear_q4_0.mm_xetla(hidden_states, self.qkv_proj_qweight)
                     query_states = qkv_states[:, :, :hidden_size]
                     key_states = qkv_states[:, :, hidden_size:2*hidden_size]
                     value_states = qkv_states[:, :, 2*hidden_size:]

--- a/python/llm/src/ipex_llm/transformers/models/mistral.py
+++ b/python/llm/src/ipex_llm/transformers/models/mistral.py
@@ -158,6 +158,9 @@ def mistral_model_forward_4_36(
         return_dict=return_dict,
     )
 
+def should_use_xetla_int4_qkv(self, device):
+    return device.type == "xpu" and self.q_proj.qtype in {SYM_INT4, FP8E5} and self.q_proj.enable_xetla
+
 
 def mistral_attention_forward(
     self,
@@ -361,6 +364,40 @@ def mistral_attention_forward_quantized(
     return attn_output.to(original_dtype), attn_weights, past_key_value
 
 
+def fuse_qkv_weight(q_proj, k_proj, v_proj, qtype):
+    if qtype == SYM_INT4 and q_proj.out_len == k_proj.out_len == v_proj.out_len:
+        weight_size = q_proj.out_len * q_proj.in_len // 2
+        zeros_size = q_proj.in_len * q_proj.out_len // 2 // 64
+        zeros_end = weight_size + zeros_size
+        weight_byte_shape = (q_proj.in_len//2, q_proj.out_len)
+        zeros_byte_shape = (q_proj.in_len//64, q_proj.out_len//2)
+        scales_byte_shape = (q_proj.in_len//64, q_proj.out_len*2)
+        qweight = torch.concat([q_proj.weight.data[:weight_size].reshape(weight_byte_shape),
+                                k_proj.weight.data[:weight_size].reshape(weight_byte_shape),
+                                v_proj.weight.data[:weight_size].reshape(weight_byte_shape),
+                                ], dim=-1).reshape(-1)
+        qzeros = torch.concat([q_proj.weight.data[weight_size:zeros_end].reshape(zeros_byte_shape),
+                            k_proj.weight.data[weight_size:zeros_end].reshape(zeros_byte_shape),
+                            v_proj.weight.data[weight_size:zeros_end].reshape(zeros_byte_shape),
+                            ], dim=-1).reshape(-1)
+        qscales = torch.concat([q_proj.weight.data[zeros_end:].reshape(scales_byte_shape),
+                                k_proj.weight.data[zeros_end:].reshape(scales_byte_shape),
+                                v_proj.weight.data[zeros_end:].reshape(scales_byte_shape),
+                                ], dim=-1).reshape(-1)
+        q_proj.weight.data = torch.empty(0)
+        k_proj.weight.data = torch.empty(0)
+        v_proj.weight.data = torch.empty(0)
+        return torch.cat([qweight, qzeros, qscales], dim=0)
+    elif qtype == FP8E5:
+        result = torch.cat([q_proj.weight, k_proj.weight, v_proj.weight], dim=1).contiguous()
+        q_proj.weight.data = torch.empty(0)
+        k_proj.weight.data = torch.empty(0)
+        v_proj.weight.data = torch.empty(0)
+        return result
+    else:
+        invalidInputError(False, f"Unsupported qtype {qtype}")
+
+
 def mistral_attention_forward_original(
     self,
     hidden_states: torch.Tensor,
@@ -402,9 +439,25 @@ def mistral_attention_forward_original(
                                                                          self.head_dim)
         kv_seq_len += 1
     else:
-        query_states = self.q_proj(hidden_states)
-        key_states = self.k_proj(hidden_states)
-        value_states = self.v_proj(hidden_states)
+
+        if should_use_xetla_int4_qkv(self, device):
+            if not hasattr(self, "qkv_proj_qweight"):
+                self.qkv_proj_qweight = fuse_qkv_weight(self.q_proj,
+                                                        self.k_proj,
+                                                        self.v_proj,
+                                                        self.q_proj.qtype)
+            import linear_q4_0
+            q_out_len = self.q_proj.out_len
+            k_out_len = self.k_proj.out_len
+            v_out_len = self.v_proj.out_len
+            qkv_states = linear_q4_0.mm_xetla(hidden_states, self.qkv_proj_qweight, self.q_proj.qtype)
+            query_states = qkv_states[:, :, :q_out_len]
+            key_states = qkv_states[:, :, q_out_len:q_out_len + k_out_len]
+            value_states = qkv_states[:, :, q_out_len + k_out_len:]
+        else:
+            query_states = self.q_proj(hidden_states)
+            key_states = self.k_proj(hidden_states)
+            value_states = self.v_proj(hidden_states)
 
         query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
         key_states = key_states.view(bsz, q_len,
@@ -769,9 +822,24 @@ def mistral_attention_forward_4_36_original(
         past_key_value.value_cache[self.layer_idx] = value_states
 
     else:
-        query_states = self.q_proj(hidden_states)
-        key_states = self.k_proj(hidden_states)
-        value_states = self.v_proj(hidden_states)
+        if should_use_xetla_int4_qkv(self, device):
+            if not hasattr(self, "qkv_proj_qweight"):
+                self.qkv_proj_qweight = fuse_qkv_weight(self.q_proj,
+                                                        self.k_proj,
+                                                        self.v_proj,
+                                                        self.q_proj.qtype)
+            import linear_q4_0
+            q_out_len = self.q_proj.out_len
+            k_out_len = self.k_proj.out_len
+            v_out_len = self.v_proj.out_len
+            qkv_states = linear_q4_0.mm_xetla(hidden_states, self.qkv_proj_qweight, self.q_proj.qtype)
+            query_states = qkv_states[:, :, :q_out_len]
+            key_states = qkv_states[:, :, q_out_len:q_out_len + k_out_len]
+            value_states = qkv_states[:, :, q_out_len + k_out_len:]
+        else:
+            query_states = self.q_proj(hidden_states)
+            key_states = self.k_proj(hidden_states)
+            value_states = self.v_proj(hidden_states)
 
         query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
         key_states = key_states.view(bsz, q_len,

--- a/python/llm/src/ipex_llm/transformers/models/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/models/qwen.py
@@ -142,6 +142,7 @@ def qwen_attention_forward_original(
     use_fuse_rope = should_use_fuse_rope(self, hidden_states)
     qtype_check = decoding_fast_path_qtype_check(self.q_proj)
     decoding_fast_path = (qtype_check and use_fuse_rope and bsz * q_len == 1)
+    decoding_fast_path = decoding_fast_path and not self.q_proj.enable_xetla
     if decoding_fast_path:
         hidden_states = hidden_states.view(1, -1)
         cache_k, cache_v = layer_past[0], layer_past[1]

--- a/python/llm/src/ipex_llm/transformers/models/qwen_vl.py
+++ b/python/llm/src/ipex_llm/transformers/models/qwen_vl.py
@@ -91,6 +91,7 @@ def qwen_attention_forward_vl(
     use_fuse_rope = should_use_fuse_rope(self, hidden_states)
     qtype_check = decoding_fast_path_qtype_check(self.q_proj)
     decoding_fast_path = (qtype_check and use_fuse_rope and bsz * q_len == 1)
+    decoding_fast_path = decoding_fast_path and not self.q_proj.enable_xetla
     if decoding_fast_path:
         hidden_states = hidden_states.view(1, -1)
         cache_k, cache_v = layer_past[0], layer_past[1]

--- a/python/llm/src/ipex_llm/transformers/models/yuan.py
+++ b/python/llm/src/ipex_llm/transformers/models/yuan.py
@@ -43,7 +43,8 @@ KV_CACHE_ALLOC_BLOCK_LENGTH = 256
 
 def use_decoding_fast_path(proj, use_fuse_rope, enough_kv_room, bs):
     return decoding_fast_path_qtype_check(proj) and \
-        use_fuse_rope and enough_kv_room and bs == 1
+        use_fuse_rope and enough_kv_room and bs == 1 \
+        and not proj.enable_xetla
 
 
 def should_use_fuse_rope(self, hidden_states, position_ids):


### PR DESCRIPTION
## Description

### 1. Why the change?

Support fp8 in xetla path and fixed several bugs.

### 2. User API changes

No

### 3. Summary of the change 
1. adapt latest changes in core-xe to rename `mm_int4` to `mm_xetla`
2. support moving back to cpu
3. support fp8
4. add fuse qkv to mistral

### 4. How to test?
- [x] Unit test
- [x] manually tested

### 5. New dependencies

No
