### PR TITLE
LLM: support iq1_s

### DIFF
--- a/python/llm/src/ipex_llm/ggml/quantize.py
+++ b/python/llm/src/ipex_llm/ggml/quantize.py
@@ -42,7 +42,9 @@ ggml_tensor_qtype = {"sym_int4": 2,   # q4_0 in ggml
                      "bf16": 20,
                      "gguf_iq2_xxs": 21,
                      "gguf_iq2_xs": 22,
-                     "q2_k": 23}
+                     "q2_k": 23,
+                     "gguf_iq1_s": 24,
+                     "gguf_iq1_m": 25}
 
 _llama_quantize_type = {"q4_0": 2,
                         "q4_1": 3,

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -263,7 +263,6 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                                                                        full_module_name,
                                                                        imatrix_data,
                                                                        model_type)
-                    print(full_module_name, qtype, cur_qtype)
                     device = module.weight.data.device
                     # Copy the weights
                     paramsLowBit = FP4Params(data=module.weight.data,

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -263,6 +263,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                                                                        full_module_name,
                                                                        imatrix_data,
                                                                        model_type)
+                    print(full_module_name, qtype, cur_qtype)
                     device = module.weight.data.device
                     # Copy the weights
                     paramsLowBit = FP4Params(data=module.weight.data,

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -73,7 +73,7 @@ FP8E5 = ggml_tensor_qtype["fp8_e5m2"]
 IQ2_XXS = ggml_tensor_qtype["gguf_iq2_xxs"]
 IQ2_XS = ggml_tensor_qtype["gguf_iq2_xs"]
 Q2_K = ggml_tensor_qtype["q2_k"]
-
+IQ1_S = ggml_tensor_qtype["gguf_iq1_s"]
 
 # The ggml_weight is col major and packs two rows at a stride of Q4_0//2.
 #
@@ -156,7 +156,7 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
     if not convert_shape_only and device != 'meta':
         dst = ctypes.c_void_p(dst_tensor.data.data_ptr())
         hist = (ctypes.c_int64 * 16)()
-        if qtype not in [IQ2_XXS, IQ2_XS, Q2_K]:
+        if qtype not in [IQ2_XXS, IQ2_XS, Q2_K, IQ1_S]:
             ggml.ggml_quantize_tensor(src, dst, qtype, n, k, hist)
         else:
             if imatrix is not None:

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -118,7 +118,8 @@ class _BaseAutoModelClass:
         :param load_in_low_bit: str value, options are ``'sym_int4'``, ``'asym_int4'``,
                                 ``'sym_int5'``, ``'asym_int5'``, ``'sym_int8'``, ``'nf3'``,
                                 ``'nf4'``, ``'fp4'``, ``'fp8'``, ``'fp8_e4m3'``, ``'fp8_e5m2'``,
-                                ``'gguf_iq2_xxs'``, ``'gguf_iq2_xs'``, ``'fp16'`` or ``'bf16'``,
+                                ``'gguf_iq2_xxs'``, ``'gguf_iq2_xs'``, gguf_iq1_s'``,
+                                ``'fp16'`` or ``'bf16'``,
                                 ``'sym_int4'`` means symmetric int 4, ``'asym_int4'`` means
                                 asymmetric int 4, ``'nf4'`` means 4-bit NormalFloat, etc.
                                 Relevant low bit optimizations will be applied to the model.
@@ -304,14 +305,14 @@ class _BaseAutoModelClass:
                     kwargs["pretraining_tp"] = 1
             q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
             imatrix_file = kwargs.pop("imatrix", None)
-            if q_k in ["gguf_iq2_xxs", "gguf_iq2_xs"]:
+            if q_k in ["gguf_iq2_xxs", "gguf_iq2_xs", "gguf_iq1_s"]:
                 invalidInputError(imatrix_file is not None,
-                                  "For gguf_iq2_xxs and gguf_iq2_xs quantization,"
+                                  "For gguf_iq2 and gguf_iq1 quantization,"
                                   "imatrix is needed.")
             cpu_embedding = kwargs.get("cpu_embedding", False)
             # for 2bit, default use embedding_quantization
-            if q_k in ["gguf_iq2_xxs", "gguf_iq2_xs", "q2_k"] and not cpu_embedding and \
-                    embedding_qtype is None:
+            if q_k in ["gguf_iq2_xxs", "gguf_iq2_xs", "gguf_iq1_s", "q2_k"] and \
+                not cpu_embedding and embedding_qtype is None:
                 embedding_qtype = "q2_k"
             if imatrix_file is not None:
                 imatrix_data = load_imatrix_data(imatrix_file)
@@ -361,7 +362,7 @@ class _BaseAutoModelClass:
                           f"Unknown load_in_low_bit value: {q_k}, expected:"
                           f" sym_int4, asym_int4, sym_int5, asym_int5, sym_int8, nf3, nf4, "
                           f"fp4, fp8, fp8_e4m3, fp8_e5m2, fp16,  bf16, gguf_iq2_xxs, "
-                          f"gguf_iq2_xs, mixed_fp4 or mixed_fp8.")
+                          f"gguf_iq2_xs, gguf_iq1_s, mixed_fp4 or mixed_fp8.")
         qtype = ggml_tensor_qtype[q_k]
 
         # In case it needs a second try,
@@ -535,7 +536,7 @@ class _BaseAutoModelClass:
         optimize_model = kwargs.pop("optimize_model", True)
 
         qtype = ggml_tensor_qtype[bigdl_transformers_low_bit]
-        if bigdl_transformers_low_bit in ["gguf_iq2_xxs", "gguf_iq2_xs", "q2_k"] and \
+        if bigdl_transformers_low_bit in ["gguf_iq2_xxs", "gguf_iq2_xs", "gguf_iq1_s", "q2_k"] and \
                 not cpu_embedding:
             embedding_qtype = "q2_k"
         if embedding_qtype is not None:

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -269,7 +269,8 @@ def module_name_process(full_module_name):
 
 def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_type=None):
     cur_qtype = qtype
-    if qtype in [ggml_tensor_qtype["gguf_iq2_xxs"], ggml_tensor_qtype["gguf_iq2_xs"]]:
+    if qtype in [ggml_tensor_qtype["gguf_iq2_xxs"], ggml_tensor_qtype["gguf_iq2_xs"],
+                 ggml_tensor_qtype["gguf_iq1_s"]]:
         # For quantization which needs importance matrix
         new_module_name, layer, cur_module = module_name_process(full_module_name)
         # custom mixed quantization strategy
@@ -282,6 +283,8 @@ def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_type=
         else:
             if cur_module == 'v' or (cur_module == 'down' and int(layer) in [0, 1, 10, 11]):
                 cur_qtype = ggml_tensor_qtype['q2_k']
+            if qtype == ggml_tensor_qtype["gguf_iq1_s"] and cur_module == 'o':
+                cur_qtype = ggml_tensor_qtype['iq2_xxs']
         if imatrix_data is not None and new_module_name in imatrix_data:
             cur_imatrix = imatrix_data[new_module_name]
         else:

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -284,7 +284,7 @@ def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_type=
             if cur_module == 'v' or (cur_module == 'down' and int(layer) in [0, 1, 10, 11]):
                 cur_qtype = ggml_tensor_qtype['q2_k']
             if qtype == ggml_tensor_qtype["gguf_iq1_s"] and cur_module == 'o':
-                cur_qtype = ggml_tensor_qtype['iq2_xxs']
+                cur_qtype = ggml_tensor_qtype['gguf_iq2_xxs']
         if imatrix_data is not None and new_module_name in imatrix_data:
             cur_imatrix = imatrix_data[new_module_name]
         else:


### PR DESCRIPTION
## Description

should merge after https://github.com/intel-analytics/llm.cpp/pull/308 .

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/1213

### 2. User API changes
mistral-7b-instruct-v0.2.imatrix is downloaded from https://huggingface.co/datasets/ikawrakow/imatrix-from-wiki-train/tree/main
```python
model = AutoModelForCausalLM.from_pretrained('mistral/Mistral-7B-Instruct-v0.2',
                                             load_in_low_bit='gguf_iq1_s',
                                             trust_remote_code=True,
                                             imatrix='mistral-7b-instruct-v0.2.imatrix',
                                             torch_dtype=torch.float16,
                                             optimize_model=True)
# save and load
model.save_low_bit("Mistral-7B-Instruct-v0.2-iq1-s")
model = AutoModelForCausalLM.load_low_bit("Mistral-7B-Instruct-v0.2-iq1-s",
                                           torch_dtype=torch.float16,
                                           trust_remote_code=True)
```

### 3. Summary of the change 

- add iq1_s support
- update mixed quantization strategy of llama2-7b

### 4. How to test?
- [ ] Unit test
- [ ] Local test 

### 5. Sample output of `mistral/Mistral-7B-Instruct-v0.2`
```bash
-------------------- Prompt --------------------
What is AI?
-------------------- Output --------------------
What is AI?

Artificial intelligence (AI) is a technology that can be used to replicate human-like intelligence, or the ability to think and learn. It
```
