### PR TITLE
Enable kv cache quantization by default for flex when 1 < batch <= 8

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/utils.py
+++ b/python/llm/src/ipex_llm/transformers/models/utils.py
@@ -73,7 +73,7 @@ def append_kv_cache(cache_k, cache_v, key_states, value_states):
 
 def use_quantize_kv_cache(linear: torch.nn.Module, x: torch.Tensor) -> bool:
     if os.environ.get("BIGDL_QUANTIZE_KV_CACHE", None) is not None:
-        return os.environ["BIGDL_QUANTIZE_KV_CACHE"] == "1"
+        return int(os.environ["BIGDL_QUANTIZE_KV_CACHE"]) == 1
     else:
         return x.device.type == 'xpu' and kv_cache_device_check(x) \
             and hasattr(linear, "qtype") and \

--- a/python/llm/src/ipex_llm/transformers/models/utils.py
+++ b/python/llm/src/ipex_llm/transformers/models/utils.py
@@ -82,7 +82,8 @@ def use_quantize_kv_cache(linear: torch.nn.Module, x: torch.Tensor) -> bool:
 
 def kv_cache_device_check(x: torch.Tensor) -> bool:
     return get_xpu_device_type(x) == "mtl" or \
-        (get_xpu_device_type(x) == "arc" and 1 < x.size(0) and x.size(0) < 8)
+        ((get_xpu_device_type(x) == "arc" or get_xpu_device_type(x) == "flex") and \
+            1 < x.size(0) and x.size(0) < 8)
 
 
 def init_fp8_kv_cache(batch_size, num_heads, current_length, head_dim, device, new_layout=False):

--- a/python/llm/src/ipex_llm/transformers/models/utils.py
+++ b/python/llm/src/ipex_llm/transformers/models/utils.py
@@ -83,7 +83,7 @@ def use_quantize_kv_cache(linear: torch.nn.Module, x: torch.Tensor) -> bool:
 def kv_cache_device_check(x: torch.Tensor) -> bool:
     return get_xpu_device_type(x) == "mtl" or \
         ((get_xpu_device_type(x) == "arc" or get_xpu_device_type(x) == "flex") and \
-            1 < x.size(0) and x.size(0) < 8)
+            1 < x.size(0) and x.size(0) <= 8)
 
 
 def init_fp8_kv_cache(batch_size, num_heads, current_length, head_dim, device, new_layout=False):


### PR DESCRIPTION
## Description

Enable kv cache quantization by default for flex when 1 < batch <= 8.
Change up bound from <8 to <=8.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

