### PR TITLE
LLM: support iq1s for llama2-70b-hf

### DIFF
--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -267,8 +267,12 @@ def module_name_process(full_module_name):
     return new_module_name, layer, cur_module
 
 
-def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_type=None):
+def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_config=None):
     cur_qtype = qtype
+    if model_config is not None:
+        model_type = getattr(model_config, "model_type", None)
+    else:
+        model_dtype = None
     if qtype in [ggml_tensor_qtype["gguf_iq2_xxs"], ggml_tensor_qtype["gguf_iq2_xs"],
                  ggml_tensor_qtype["gguf_iq1_s"]]:
         # For quantization which needs importance matrix
@@ -281,7 +285,15 @@ def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_type=
             elif cur_module == 'down' and int(layer) in [0, 1, 2, 3]:
                 cur_qtype = ggml_tensor_qtype['q2_k']
         else:
-            if cur_module == 'v' or (cur_module == 'down' and int(layer) in [0, 1, 10, 11]):
+            num_hidden_layers = getattr(model_config, "num_hidden_layers", None)
+            hidden_size = getattr(model_config, "hidden_size", None)
+            if model_type == "llama" and hidden_size == 8192:
+                # for llama2-70b
+                if cur_module == 'v':
+                    cur_qtype = ggml_tensor_qtype['sym_int4']  # llama.cpp use q4k here
+                if cur_module == 'down' and int(layer) < int(num_hidden_layers/8):
+                    cur_qtype = ggml_tensor_qtype['q2_k']
+            elif cur_module == 'v' or (cur_module == 'down' and int(layer) in [0, 1, 10, 11]):
                 cur_qtype = ggml_tensor_qtype['q2_k']
             if qtype == ggml_tensor_qtype["gguf_iq1_s"] and cur_module == 'o':
                 cur_qtype = ggml_tensor_qtype['gguf_iq2_xxs']


### PR DESCRIPTION
## Description

### 1. Why the change?

support iq1s for llama2-70b-hf

### 2. User API changes
`llama-v2-70b.imatrix` is downloaded from https://huggingface.co/datasets/ikawrakow/imatrix-from-wiki-train/tree/main
```python
model = AutoModelForCausalLM.from_pretrained('meta-llama/Llama-2-70b-chat-hf',
                                             load_in_low_bit='gguf_iq1_s',
                                             torch_dtype=torch.float16,
                                             trust_remote_code=True,
                                             imatrix='llama-v2-70b.imatrix')
# save & load
model.save_low_bit("Llama-2-70b-chat-hf-iq1s")
model = AutoModelForCausalLM.load_low_bit("Llama-2-70b-chat-hf-iq1s",
                                          torch_dtype=torch.float16,
                                          optimize_model=True)
model = model.to("xpu")
```

### 3. Summary of the change 

- support iq1s for llama2-70b-hf

### 4. How to test?
- [x] Local test on PVC
- [x] Local test on ARC
- [ ] Unit test

### 5. Sample output of `Llama-2-70b-chat-hf` on ARC A770
```bash
-------------------- Prompt --------------------
### HUMAN:
What is AI?

### RESPONSE:

-------------------- Output --------------------
### HUMAN:
What is AI?

### RESPONSE:
AI stands for Artificial Intelligence. It's a field of research and development that focuses on creating machines that can think, learn, and
```