### PR TITLE
Fix dtype mismatch error

### DIFF
--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -295,6 +295,15 @@ class _BaseAutoModelClass:
                     )
                 else:
                     kwargs["torch_dtype"] = torch.float16
+            elif load_in_low_bit == "bf16":
+                if torch_dtype is not None and torch_dtype != torch.bfloat16:
+                    invalidInputError(
+                            False,
+                            f"Please use torch_dtype=torch.bfloat16"
+                            f" when setting load_in_low_bit='bf16'."
+                        )
+                else:
+                    kwargs["torch_dtype"] = torch.bfloat16
             else:
                 kwargs["torch_dtype"] = torch_dtype or "auto"
             # Avoid tensor parallel F.Linear Operations

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -298,10 +298,10 @@ class _BaseAutoModelClass:
             elif load_in_low_bit == "bf16":
                 if torch_dtype is not None and torch_dtype != torch.bfloat16:
                     invalidInputError(
-                            False,
-                            f"Please use torch_dtype=torch.bfloat16"
-                            f" when setting load_in_low_bit='bf16'."
-                        )
+                        False,
+                        f"Please use torch_dtype=torch.bfloat16"
+                        f" when setting load_in_low_bit='bf16'."
+                    )
                 else:
                     kwargs["torch_dtype"] = torch.bfloat16
             else:

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1324,6 +1324,8 @@ def native_sdp(query, key, value, attention_mask,
 
     # at inference time, for memory considerations, may not need to upcast attention to fp32
     attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+    if attn_weights.dtype != value.dtype:
+        attn_weights = attn_weights.to(value.dtype)
     attn_output = torch.matmul(attn_weights, value)
     return attn_output, attn_weights
 

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1324,8 +1324,10 @@ def native_sdp(query, key, value, attention_mask,
 
     # at inference time, for memory considerations, may not need to upcast attention to fp32
     attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+
     if attn_weights.dtype != value.dtype:
         attn_weights = attn_weights.to(value.dtype)
+
     attn_output = torch.matmul(attn_weights, value)
     return attn_output, attn_weights
 

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1325,9 +1325,6 @@ def native_sdp(query, key, value, attention_mask,
     # at inference time, for memory considerations, may not need to upcast attention to fp32
     attn_weights = nn.functional.softmax(attn_weights, dim=-1)
 
-    if attn_weights.dtype != value.dtype:
-        attn_weights = attn_weights.to(value.dtype)
-
     attn_output = torch.matmul(attn_weights, value)
     return attn_output, attn_weights
 


### PR DESCRIPTION
Fix dtype mismatch error when `load_in_low_bit='bf16'` 
CPU and GPU both: RuntimeError: expected m1 and m2 to have the same dtype, but got: float != c10::BFloat16 and details could be found in the issue https://github.com/analytics-zoo/nano/issues/1111