### PR TITLE
Fix starcoder first token perf

### DIFF
--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -538,7 +538,7 @@ class LowBitLinear(nn.Linear):
         # The condition makes sure that empty cache only takes effect if this layer is lm_head.
         # For other models like llama, lm_cache will be applied as well
         # since performance isn't impacted.
-        self.is_lm_head = self.in_len * self.out_len >= 30000 * 4096
+        self.is_lm_head = self.in_len * self.out_len >= 30000 * 4096 and self.bias is None
         self.low_memory_mode = self.is_lm_head
 
     def forward(self, x: torch.Tensor):

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -538,7 +538,7 @@ class LowBitLinear(nn.Linear):
         # The condition makes sure that empty cache only takes effect if this layer is lm_head.
         # For other models like llama, lm_cache will be applied as well
         # since performance isn't impacted.
-        self.is_lm_head = self.in_len * self.out_len >= 30000 * 4096 and self.bias is None
+        self.is_lm_head = self.in_len * self.out_len >= 32000 * 4096 and self.bias is None
         self.low_memory_mode = self.is_lm_head
 
     def forward(self, x: torch.Tensor):


### PR DESCRIPTION
Fix https://github.com/analytics-zoo/nano/issues/1203

          (c_fc): LowBitLinear(in_features=6144, out_features=24576, bias=True)
          (c_proj): LowBitLinear(in_features=24576, out_features=6144, bias=True)

For starcoder mlp, it has large in/out features as well, `24576*6144>32000*4096`, larger than llama's lm_head. empty cache is executed within each transformer block and thus the first token latency is hugely impacted.
Add a condition for bias to exclude these layers. For lm_head seems it won't have bias.