### PR TITLE
add test api transformer_int4_fp16_gpu

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -23,8 +23,7 @@ Config YAML file has following format
 
 ```yaml
 repo_id:
-  - 'THUDM/chatglm-6b'
-  - 'THUDM/chatglm2-6b'
+  # - 'THUDM/chatglm2-6b'
   - 'meta-llama/Llama-2-7b-chat-hf'
   # - 'liuhaotian/llava-v1.5-7b' # requires a LLAVA_REPO_DIR env variables pointing to the llava dir; added only for gpu win related test_api now
 local_model_hub: 'path to your local model hub'
@@ -37,21 +36,29 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
-  - "transformer_int4"
-  - "native_int4"
-  - "optimize_model"
-  - "pytorch_autocast_bf16"
-  # - "transformer_autocast_bf16"
   # - "ipex_fp16_gpu" # on Intel GPU
   # - "bigdl_fp16_gpu" # on Intel GPU
-  # - "transformer_int4_gpu"  # on Intel GPU
+  - "transformer_int4_gpu"  # on Intel GPU
+  # - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
   # - "optimize_model_gpu"  # on Intel GPU
   # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
   # - "transformer_int4_gpu_win" # on Intel GPU for Windows
   # - "transformer_int4_fp16_gpu_win" # on Intel GPU for Windows, use fp16 for non-linear layer
   # - "transformer_int4_loadlowbit_gpu_win" # on Intel GPU for Windows using load_low_bit API. Please make sure you have used the save.py to save the converted low bit model
+  # - "deepspeed_optimize_model_gpu" # deepspeed autotp on Intel GPU
+  # - "speculative_gpu"
+  # - "transformer_int4"
+  # - "native_int4"
+  # - "optimize_model"
+  # - "pytorch_autocast_bf16"
+  # - "transformer_autocast_bf16"
+  # - "bigdl_ipex_bf16"
+  # - "bigdl_ipex_int4"
+  # - "bigdl_ipex_int8"
+  # - "speculative_cpu"
 cpu_embedding: False # whether put embedding to CPU (only avaiable now for gpu win related test_api)
 streaming: False # whether output in streaming way (only avaiable now for gpu win related test_api)
+
 
 ```
 

--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -2,7 +2,7 @@
 
 All in one benchmark test allows users to test all the benchmarks and record them in a result CSV. Users can provide models and related information in `config.yaml`.
 
-Before running, make sure to have [ipex-llm](../../../../../README.md).
+Before running, make sure to have [ipex-llm](../../../../../README.md) installed.
 
 ## Dependencies
 
@@ -41,7 +41,6 @@ test_api:
   # - "ipex_fp16_gpu" # on Intel GPU
   # - "bigdl_fp16_gpu" # on Intel GPU
   # - "optimize_model_gpu"  # on Intel GPU
-  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
   # - "transformer_int4_gpu_win" # on Intel GPU for Windows
   # - "transformer_int4_fp16_gpu_win" # on Intel GPU for Windows, use fp16 for non-linear layer
   # - "transformer_int4_loadlowbit_gpu_win" # on Intel GPU for Windows using load_low_bit API. Please make sure you have used the save.py to save the converted low bit model
@@ -56,6 +55,7 @@ test_api:
   # - "bigdl_ipex_int4"
   # - "bigdl_ipex_int8"
   # - "speculative_cpu"
+  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
 cpu_embedding: False # whether put embedding to CPU (only avaiable now for gpu win related test_api)
 streaming: False # whether output in streaming way (only avaiable now for gpu win related test_api)
 

--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -2,7 +2,7 @@
 
 All in one benchmark test allows users to test all the benchmarks and record them in a result CSV. Users can provide models and related information in `config.yaml`.
 
-Before running, make sure to have [bigdl-llm](../../../README.md).
+Before running, make sure to have [ipex-llm](../../../../../README.md).
 
 ## Dependencies
 
@@ -36,10 +36,10 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
-  # - "ipex_fp16_gpu" # on Intel GPU
-  # - "bigdl_fp16_gpu" # on Intel GPU
   - "transformer_int4_gpu"  # on Intel GPU
   # - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
+  # - "ipex_fp16_gpu" # on Intel GPU
+  # - "bigdl_fp16_gpu" # on Intel GPU
   # - "optimize_model_gpu"  # on Intel GPU
   # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
   # - "transformer_int4_gpu_win" # on Intel GPU for Windows

--- a/python/llm/dev/benchmark/all-in-one/config.yaml
+++ b/python/llm/dev/benchmark/all-in-one/config.yaml
@@ -12,10 +12,10 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
-  # - "ipex_fp16_gpu" # on Intel GPU
-  # - "bigdl_fp16_gpu" # on Intel GPU
   - "transformer_int4_gpu"  # on Intel GPU
   # - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
+  # - "ipex_fp16_gpu" # on Intel GPU
+  # - "bigdl_fp16_gpu" # on Intel GPU
   # - "optimize_model_gpu"  # on Intel GPU
   # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
   # - "transformer_int4_gpu_win" # on Intel GPU for Windows

--- a/python/llm/dev/benchmark/all-in-one/config.yaml
+++ b/python/llm/dev/benchmark/all-in-one/config.yaml
@@ -1,10 +1,8 @@
 repo_id:
-  - 'THUDM/chatglm2-6b'
+  # - 'THUDM/chatglm2-6b'
   - 'meta-llama/Llama-2-7b-chat-hf'
-  - 'Qwen/Qwen-7B-Chat'
-  - 'baichuan-inc/Baichuan2-7B-Chat-LLaMAfied'
   # - 'liuhaotian/llava-v1.5-7b' # requires a LLAVA_REPO_DIR env variables pointing to the llava dir; added only for gpu win related test_api now
-local_model_hub: '/mnt/disk1/models'
+local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3
 num_beams: 1 # default to greedy search
@@ -14,12 +12,11 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
-  # - "transformer_int4_gpu"  # on Intel GPU
-  - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
+  - "transformer_int4_gpu"  # on Intel GPU
+  # - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
   # - "ipex_fp16_gpu" # on Intel GPU
   # - "bigdl_fp16_gpu" # on Intel GPU
   # - "optimize_model_gpu"  # on Intel GPU
-  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
   # - "transformer_int4_gpu_win" # on Intel GPU for Windows
   # - "transformer_int4_fp16_gpu_win" # on Intel GPU for Windows, use fp16 for non-linear layer
   # - "transformer_int4_loadlowbit_gpu_win" # on Intel GPU for Windows using load_low_bit API. Please make sure you have used the save.py to save the converted low bit model
@@ -34,5 +31,6 @@ test_api:
   # - "bigdl_ipex_int4"
   # - "bigdl_ipex_int8"
   # - "speculative_cpu"
+  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
 cpu_embedding: False # whether put embedding to CPU (only avaiable now for gpu win related test_api)
 streaming: False # whether output in streaming way (only avaiable now for gpu win related test_api)

--- a/python/llm/dev/benchmark/all-in-one/config.yaml
+++ b/python/llm/dev/benchmark/all-in-one/config.yaml
@@ -1,8 +1,10 @@
 repo_id:
-  # - 'THUDM/chatglm2-6b'
+  - 'THUDM/chatglm2-6b'
   - 'meta-llama/Llama-2-7b-chat-hf'
+  - 'Qwen/Qwen-7B-Chat'
+  - 'baichuan-inc/Baichuan2-7B-Chat-LLaMAfied'
   # - 'liuhaotian/llava-v1.5-7b' # requires a LLAVA_REPO_DIR env variables pointing to the llava dir; added only for gpu win related test_api now
-local_model_hub: 'path to your local model hub'
+local_model_hub: '/mnt/disk1/models'
 warm_up: 1
 num_trials: 3
 num_beams: 1 # default to greedy search
@@ -12,8 +14,8 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
-  - "transformer_int4_gpu"  # on Intel GPU
-  # - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
+  # - "transformer_int4_gpu"  # on Intel GPU
+  - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
   # - "ipex_fp16_gpu" # on Intel GPU
   # - "bigdl_fp16_gpu" # on Intel GPU
   # - "optimize_model_gpu"  # on Intel GPU

--- a/python/llm/dev/benchmark/all-in-one/config.yaml
+++ b/python/llm/dev/benchmark/all-in-one/config.yaml
@@ -1,9 +1,8 @@
 repo_id:
-  # - 'THUDM/chatglm-6b'
   # - 'THUDM/chatglm2-6b'
   - 'meta-llama/Llama-2-7b-chat-hf'
   # - 'liuhaotian/llava-v1.5-7b' # requires a LLAVA_REPO_DIR env variables pointing to the llava dir; added only for gpu win related test_api now
-local_model_hub: '/mnt/disk1/models'
+local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3
 num_beams: 1 # default to greedy search
@@ -13,6 +12,17 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
+  # - "ipex_fp16_gpu" # on Intel GPU
+  # - "bigdl_fp16_gpu" # on Intel GPU
+  - "transformer_int4_gpu"  # on Intel GPU
+  # - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
+  # - "optimize_model_gpu"  # on Intel GPU
+  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
+  # - "transformer_int4_gpu_win" # on Intel GPU for Windows
+  # - "transformer_int4_fp16_gpu_win" # on Intel GPU for Windows, use fp16 for non-linear layer
+  # - "transformer_int4_loadlowbit_gpu_win" # on Intel GPU for Windows using load_low_bit API. Please make sure you have used the save.py to save the converted low bit model
+  # - "deepspeed_optimize_model_gpu" # deepspeed autotp on Intel GPU
+  # - "speculative_gpu"
   # - "transformer_int4"
   # - "native_int4"
   # - "optimize_model"
@@ -21,17 +31,6 @@ test_api:
   # - "bigdl_ipex_bf16"
   # - "bigdl_ipex_int4"
   # - "bigdl_ipex_int8"
-  # - "ipex_fp16_gpu" # on Intel GPU
-  # - "bigdl_fp16_gpu" # on Intel GPU
-  - "transformer_int4_gpu"  # on Intel GPU
-  - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
-  # - "optimize_model_gpu"  # on Intel GPU
-  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
-  # - "transformer_int4_gpu_win" # on Intel GPU for Windows
-  # - "transformer_int4_fp16_gpu_win" # on Intel GPU for Windows, use fp16 for non-linear layer
-  # - "transformer_int4_loadlowbit_gpu_win" # on Intel GPU for Windows using load_low_bit API. Please make sure you have used the save.py to save the converted low bit model
-  # - "deepspeed_optimize_model_gpu" # deepspeed autotp on Intel GPU
   # - "speculative_cpu"
-  # - "speculative_gpu"
 cpu_embedding: False # whether put embedding to CPU (only avaiable now for gpu win related test_api)
 streaming: False # whether output in streaming way (only avaiable now for gpu win related test_api)

--- a/python/llm/dev/benchmark/all-in-one/config.yaml
+++ b/python/llm/dev/benchmark/all-in-one/config.yaml
@@ -1,9 +1,9 @@
 repo_id:
-  - 'THUDM/chatglm-6b'
-  - 'THUDM/chatglm2-6b'
+  # - 'THUDM/chatglm-6b'
+  # - 'THUDM/chatglm2-6b'
   - 'meta-llama/Llama-2-7b-chat-hf'
   # - 'liuhaotian/llava-v1.5-7b' # requires a LLAVA_REPO_DIR env variables pointing to the llava dir; added only for gpu win related test_api now
-local_model_hub: 'path to your local model hub'
+local_model_hub: '/mnt/disk1/models'
 warm_up: 1
 num_trials: 3
 num_beams: 1 # default to greedy search
@@ -13,17 +13,18 @@ in_out_pairs:
   - '32-32'
   - '1024-128'
 test_api:
-  - "transformer_int4"
-  - "native_int4"
-  - "optimize_model"
-  - "pytorch_autocast_bf16"
+  # - "transformer_int4"
+  # - "native_int4"
+  # - "optimize_model"
+  # - "pytorch_autocast_bf16"
   # - "transformer_autocast_bf16"
   # - "bigdl_ipex_bf16"
   # - "bigdl_ipex_int4"
   # - "bigdl_ipex_int8"
   # - "ipex_fp16_gpu" # on Intel GPU
   # - "bigdl_fp16_gpu" # on Intel GPU
-  # - "transformer_int4_gpu"  # on Intel GPU
+  - "transformer_int4_gpu"  # on Intel GPU
+  - "transformer_int4_fp16_gpu" # on Intel GPU, use fp16 for non-linear layer
   # - "optimize_model_gpu"  # on Intel GPU
   # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
   # - "transformer_int4_gpu_win" # on Intel GPU for Windows

--- a/python/llm/dev/benchmark/all-in-one/run.py
+++ b/python/llm/dev/benchmark/all-in-one/run.py
@@ -74,6 +74,8 @@ def run_model(repo_id, test_api, in_out_pairs, local_model_hub=None, warm_up=1, 
         result = run_optimize_model(repo_id, local_model_hub, in_out_pairs, warm_up, num_trials, num_beams, low_bit, batch_size)
     elif test_api == 'transformer_int4_gpu':
         result = run_transformer_int4_gpu(repo_id, local_model_hub, in_out_pairs, warm_up, num_trials, num_beams, low_bit, batch_size)
+    elif test_api == 'transformer_int4_fp16_gpu':
+        result = run_transformer_int4_gpu(repo_id, local_model_hub, in_out_pairs, warm_up, num_trials, num_beams, low_bit, batch_size, fp16=True)
     elif test_api == 'optimize_model_gpu':
         result = run_optimize_model_gpu(repo_id, local_model_hub, in_out_pairs, warm_up, num_trials, num_beams, low_bit, batch_size)
     elif test_api == 'pytorch_autocast_bf16':
@@ -388,7 +390,8 @@ def run_transformer_int4_gpu(repo_id,
                              num_trials,
                              num_beams,
                              low_bit,
-                             batch_size):
+                             batch_size,
+                             fp16=False):
     from ipex_llm.transformers import AutoModel, AutoModelForCausalLM
     from transformers import AutoTokenizer, GPTJForCausalLM, LlamaTokenizer
     import intel_extension_for_pytorch as ipex
@@ -427,6 +430,11 @@ def run_transformer_int4_gpu(repo_id,
                                                             trust_remote_code=True, use_cache=True).eval()
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
         model = model.to('xpu')
+
+    if fp16:
+        model = model.half()
+        print("Convert model to half precision")
+
     end = time.perf_counter()
     load_time = end - st
     print(">> loading of model costs {}s and {}GB".format(load_time, torch.xpu.memory.memory_reserved()/(1024**3)))

--- a/python/llm/dev/benchmark/all-in-one/run.py
+++ b/python/llm/dev/benchmark/all-in-one/run.py
@@ -408,12 +408,10 @@ def run_transformer_int4_gpu(repo_id,
             model = AutoModel.from_pretrained(model_path, load_in_low_bit=low_bit, optimize_model=True,
                                             trust_remote_code=True, use_cache=True).eval()
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
-        model = model.to('xpu')
     elif origin_repo_id in LLAMA_IDS:
         model = AutoModelForCausalLM.from_pretrained(model_path, load_in_low_bit=low_bit, trust_remote_code=True,
                                                      use_cache=True).eval()
         tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
-        model = model.to('xpu')
     else:
         if "4bit" in repo_id:
             model = AutoModelForCausalLM.load_low_bit(model_path, optimize_model=True,
@@ -429,11 +427,12 @@ def run_transformer_int4_gpu(repo_id,
                 model = AutoModelForCausalLM.from_pretrained(model_path, optimize_model=True, load_in_low_bit=low_bit,
                                                             trust_remote_code=True, use_cache=True).eval()
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
-        model = model.to('xpu')
 
     if fp16:
         model = model.half()
         print("Convert model to half precision")
+    
+    model = model.to('xpu')
 
     end = time.perf_counter()
     load_time = end - st


### PR DESCRIPTION
## Description
Add test api transformer_int4_fp16_gpu in all-in-one benchmark. The attached files are results of two apis.
[transformer_int4_fp16_gpu-results-2024-04-02.csv](https://github.com/intel-analytics/ipex-llm/files/14834323/transformer_int4_fp16_gpu-results-2024-04-02.csv)
[transformer_int4_gpu-results-2024-04-02.csv](https://github.com/intel-analytics/ipex-llm/files/14834325/transformer_int4_gpu-results-2024-04-02.csv)
