### PR TITLE
Update Moss-moe example README to install transformers<4.34

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/moss/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/moss/README.md
@@ -14,6 +14,7 @@ conda create -n llm python=3.9
 conda activate llm
 
 pip install ipex-llm[all] # install ipex-llm with 'all' option
+pip install "transformers<4.34"
 ```
 
 ### 2. Run


### PR DESCRIPTION
The moss-moon-003-sft cannot work on transformers 4.34+ because it does not make adaption to tokenizer changes in transformers 4.34+.
Related issue: https://github.com/analytics-zoo/nano/issues/1145