### PR TITLE
fix wrong cpu core num seen by qlora

### DIFF
--- a/docker/llm/finetune/qlora/cpu/docker/start-qlora-finetuning-on-cpu.sh
+++ b/docker/llm/finetune/qlora/cpu/docker/start-qlora-finetuning-on-cpu.sh
@@ -4,6 +4,7 @@ cd /ipex_llm
 export USE_XETLA=OFF
 export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1
 source /opt/intel/oneapi/setvars.sh
+export CPU_CORES=$(nproc)
 source ipex-llm-init -t
 
 if [ -d "./model" ];
@@ -19,7 +20,6 @@ fi
 if [ "$STANDALONE_DOCKER" = "TRUE" ]
 then
   export CONTAINER_IP=$(hostname -i)
-  export CPU_CORES=$(nproc)
   source /opt/intel/oneapi/setvars.sh
   export CCL_WORKER_COUNT=$WORKER_COUNT_DOCKER
   export CCL_WORKER_AFFINITY=auto


### PR DESCRIPTION
## Description

After **ipex-llm-init**, nproc used to see 96 cores, for example, and only can see 48 which is equal to OMP_NUM_THREADS set by source oneAPI.
This may be a bug of ipex-llm-init, and for qlora, we fix it here by nproc get cpu core num before ipex-llm-init.

### 1. Why the change?

as above

### 2. User API changes

no

### 3. Summary of the change 

fix wrong cpu core num seen by qlora

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [x] Document test
- [ ] ...