### PR TITLE
LLM: support llama2 8k input with w4a16.

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -639,11 +639,18 @@ def llama_attention_forward_4_31_original(
         attn_weights = None
     else:
         # otherwise, use native attention
-        attn_output, attn_weights = native_sdp(query_states, key_states, value_states,
+        if query_states.dtype == torch.float16 and query_states.shape[2] >= 6800:
+            # split tensor for memory block limitation
+            # support fp16 and set input length threshold at 6800 for now
+            attn_output, attn_weights = native_sdp_sp(query_states, key_states, value_states,
                                                attention_mask,
                                                bsz, q_len, kv_seq_len,
-                                               self.head_dim, self.num_heads)
-
+                                               self.head_dim)
+        else:
+            attn_output, attn_weights = native_sdp(query_states, key_states, value_states,
+                                                attention_mask,
+                                                bsz, q_len, kv_seq_len,
+                                                self.head_dim, self.num_heads)
     attn_output_size = (bsz, self.num_heads, q_len, self.head_dim)
     if attn_output.size() != attn_output_size:
         invalidInputError(False,
@@ -1345,6 +1352,34 @@ def native_sdp(query, key, value, attention_mask,
                                              dtype=torch.float32).to(value.dtype)
     attn_output = torch.matmul(attn_weights, value)
     return attn_output, attn_weights
+
+
+def native_sdp_sp(query, key, value, attention_mask,
+               bsz, q_len, kv_seq_len, head_dim):
+    query_sp = torch.split(query.to(key.dtype), 16, dim=1)
+    key_sp = torch.split(key.transpose(2, 3), 16, dim=1)
+    value_sp = torch.split(value, 16, dim=1)
+    attn_weights = []
+    for q, k, v in zip(query_sp, key_sp, value_sp):
+        attn_weights_sp = torch.matmul(q, k)/ math.sqrt(head_dim)
+        attn_weights_sp_size = (bsz, 16, q_len, kv_seq_len)
+        if attn_weights_sp.size() != attn_weights_sp_size:
+            invalidInputError(False,
+                            f"Splitted Attention weights should be of size {attn_weights_sp_size},"
+                            f" but is {attn_weights_sp.size()}")
+
+        if attention_mask is not None:
+            attn_mask_size = (bsz, 1, q_len, kv_seq_len)
+            if attention_mask.size() != attn_mask_size:
+                invalidInputError(False,
+                                f"Attention mask should be of size {attn_mask_size}, "
+                                f"but is {attention_mask.size()}")
+            attn_weights_sp = attn_weights_sp + attention_mask
+        attn_weights_sp = nn.functional.softmax(attn_weights_sp, dim=-1)
+        attn_weights_sp = torch.matmul(attn_weights_sp, v)
+        attn_weights.append(attn_weights_sp)
+    attn_output = torch.cat(attn_weights, dim=1)
+    return attn_output, None
 
 
 def llama_model_selective_batching_forward_4_31(

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -639,18 +639,19 @@ def llama_attention_forward_4_31_original(
         attn_weights = None
     else:
         # otherwise, use native attention
-        if query_states.dtype == torch.float16 and query_states.shape[2] >= 6800:
+        if not output_attentions and query_states.dtype == torch.float16 and \
+            query_states.shape[2] >= 6800:
             # split tensor for memory block limitation
             # support fp16 and set input length threshold at 6800 for now
             attn_output, attn_weights = native_sdp_sp(query_states, key_states, value_states,
-                                               attention_mask,
-                                               bsz, q_len, kv_seq_len,
-                                               self.head_dim)
+                                                      attention_mask,
+                                                      bsz, q_len, kv_seq_len,
+                                                      self.head_dim)
         else:
             attn_output, attn_weights = native_sdp(query_states, key_states, value_states,
-                                                attention_mask,
-                                                bsz, q_len, kv_seq_len,
-                                                self.head_dim, self.num_heads)
+                                                   attention_mask,
+                                                   bsz, q_len, kv_seq_len,
+                                                   self.head_dim, self.num_heads)
     attn_output_size = (bsz, self.num_heads, q_len, self.head_dim)
     if attn_output.size() != attn_output_size:
         invalidInputError(False,

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1330,7 +1330,7 @@ def llama_attention_forward_4_36_original(
 def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads, output_attentions):
     if should_split_qkv_tensor(query, output_attentions):
-        return native_sdp_split_tensor(query, key, value, attention_mask,
+        return native_sdp_split_qkv_tensor(query, key, value, attention_mask,
                                        bsz, q_len, kv_seq_len, head_dim)
     else:
         attn_weights = torch.matmul(query.to(key.dtype),
@@ -1361,7 +1361,8 @@ def native_sdp(query, key, value, attention_mask,
         return attn_output, attn_weights
 
 
-def native_sdp_split_tensor(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim):
+def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
+                                bsz, q_len, kv_seq_len, head_dim):
     query_sp = torch.split(query.to(key.dtype), 16, dim=1)
     key_sp = torch.split(key.transpose(2, 3), 16, dim=1)
     value_sp = torch.split(value, 16, dim=1)

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1383,8 +1383,8 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
                                   f"but is {attention_mask.size()}")
             attn_weights_split = attn_weights_split + attention_mask
         attn_weights_split = nn.functional.softmax(attn_weights_split, dim=-1)
-        attn_output_split = torch.matmul(attn_weights_split, v)
-        attn_outputs.append(attn_output_split)
+        attn_weights_split = torch.matmul(attn_weights_split, v)
+        attn_outputs.append(attn_weights_split)
     attn_output = torch.cat(attn_outputs, dim=1)
     return attn_output, None
 

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -214,7 +214,7 @@ def should_use_fast_rope(self, query_states, position_ids):
     return use_fuse_rope
 
 
-def should_split_tensor(query_states, output_attentions):
+def should_split_qkv_tensor(query_states, output_attentions):
     if not output_attentions and query_states.dtype == torch.float16 and \
             query_states.shape[2] >= 6800:
         # split tensor for memory block limitation
@@ -1329,7 +1329,7 @@ def llama_attention_forward_4_36_original(
 
 def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads, output_attentions):
-    if should_split_tensor(query, output_attentions):
+    if should_split_qkv_tensor(query, output_attentions):
         return native_sdp_split_tensor(query, key, value, attention_mask,
                                        bsz, q_len, kv_seq_len, head_dim)
     else:

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1330,7 +1330,8 @@ def llama_attention_forward_4_36_original(
 def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads, output_attentions):
     if should_split_tensor(query, output_attentions):
-        return native_sdp_split_tensor(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim)
+        return native_sdp_split_tensor(query, key, value, attention_mask,
+                                       bsz, q_len, kv_seq_len, head_dim)
     else:
         attn_weights = torch.matmul(query.to(key.dtype),
                                     key.transpose(2, 3)) / math.sqrt(head_dim)

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1330,7 +1330,7 @@ def llama_attention_forward_4_36_original(
 def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads, output_attentions):
     if should_split_tensor(query, output_attentions):
-        native_sdp_sp(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim)
+        return native_sdp_sp(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim)
     else:
         attn_weights = torch.matmul(query.to(key.dtype),
                                     key.transpose(2, 3)) / math.sqrt(head_dim)

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1330,7 +1330,7 @@ def llama_attention_forward_4_36_original(
 def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads, output_attentions):
     if should_split_tensor(query, output_attentions):
-        return native_sdp_sp(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim)
+        return native_sdp_split_tensor(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim)
     else:
         attn_weights = torch.matmul(query.to(key.dtype),
                                     key.transpose(2, 3)) / math.sqrt(head_dim)
@@ -1360,7 +1360,7 @@ def native_sdp(query, key, value, attention_mask,
         return attn_output, attn_weights
 
 
-def native_sdp_sp(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim):
+def native_sdp_split_tensor(query, key, value, attention_mask, bsz, q_len, kv_seq_len, head_dim):
     query_sp = torch.split(query.to(key.dtype), 16, dim=1)
     key_sp = torch.split(key.transpose(2, 3), 16, dim=1)
     value_sp = torch.split(value, 16, dim=1)

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1331,7 +1331,7 @@ def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads, output_attentions):
     if should_split_qkv_tensor(query, output_attentions):
         return native_sdp_split_qkv_tensor(query, key, value, attention_mask,
-                                       bsz, q_len, kv_seq_len, head_dim)
+                                           bsz, q_len, kv_seq_len, head_dim)
     else:
         attn_weights = torch.matmul(query.to(key.dtype),
                                     key.transpose(2, 3)) / math.sqrt(head_dim)

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -216,7 +216,7 @@ def should_use_fast_rope(self, query_states, position_ids):
 
 def should_split_tensor(query_states, output_attentions):
     if not output_attentions and query_states.dtype == torch.float16 and \
-        query_states.shape[2] >= 6800:
+            query_states.shape[2] >= 6800:
         # split tensor for memory block limitation
         # support fp16 and set input length threshold at 6800 for now
         return True

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -216,7 +216,7 @@ def should_use_fast_rope(self, query_states, position_ids):
 
 def should_split_tensor(query_states, output_attentions):
     if not output_attentions and query_states.dtype == torch.float16 and \
-                query_states.shape[2] >= 6800:
+        query_states.shape[2] >= 6800:
         # split tensor for memory block limitation
         # support fp16 and set input length threshold at 6800 for now
         return True
@@ -649,9 +649,9 @@ def llama_attention_forward_4_31_original(
     else:
         # otherwise, use native attention
         attn_output, attn_weights = native_sdp(query_states, key_states, value_states,
-                                                attention_mask,
-                                                bsz, q_len, kv_seq_len,
-                                                self.head_dim, self.num_heads, output_attentions)
+                                               attention_mask,
+                                               bsz, q_len, kv_seq_len,
+                                               self.head_dim, self.num_heads, output_attentions)
     attn_output_size = (bsz, self.num_heads, q_len, self.head_dim)
     if attn_output.size() != attn_output_size:
         invalidInputError(False,
@@ -1339,15 +1339,15 @@ def native_sdp(query, key, value, attention_mask,
         attn_weights_size = (bsz, num_heads, q_len, kv_seq_len)
         if attn_weights.size() != attn_weights_size:
             invalidInputError(False,
-                            f"Attention weights should be of size {attn_weights_size}, "
-                            f"but is {attn_weights.size()}")
+                              f"Attention weights should be of size {attn_weights_size}, "
+                              f"but is {attn_weights.size()}")
 
         if attention_mask is not None:
             attn_mask_size = (bsz, 1, q_len, kv_seq_len)
             if attention_mask.size() != attn_mask_size:
                 invalidInputError(False,
-                                f"Attention mask should be of size {attn_mask_size}, "
-                                f"but is {attention_mask.size()}")
+                                  f"Attention mask should be of size {attn_mask_size}, "
+                                  f"but is {attention_mask.size()}")
             attn_weights = attn_weights + attention_mask
 
         if kv_seq_len >= 2048:
@@ -1356,7 +1356,7 @@ def native_sdp(query, key, value, attention_mask,
         else:
             # upcast attention to fp32
             attn_weights = nn.functional.softmax(attn_weights, dim=-1,
-                                                dtype=torch.float32).to(value.dtype)
+                                                 dtype=torch.float32).to(value.dtype)
         attn_output = torch.matmul(attn_weights, value)
         return attn_output, attn_weights
 


### PR DESCRIPTION
## Description

This PR is to support llama2 8k input with w4a16

- Perf test results:
```shell
# 8k input with split tensor
0,meta-llama/Llama-2-7b-chat-hf,7574.67,22.89,0.0,8192-512,1,8193-512,1,sym_int4,N/A,3.21,12.5234375,N/A
# 4k input with split tensor
0,meta-llama/Llama-2-7b-chat-hf,2254.81,17.74,0.0,4096-512,1,4097-512,1,sym_int4,N/A,3.17,8.384765625,N/A
# 4k input without split tensor
0,meta-llama/Llama-2-7b-chat-hf,2217.67,17.71,0.0,4096-512,1,4097-512,1,sym_int4,N/A,3.09,8.361328125,N/A
```

The results shows, the split tensor optimization just affect the first token latency and do not affect rest token latency. Besides, the output of llama2-7b is abnormal when input length > 4096 (abnormal means repeat, garbled code and unknown code), yet the output results with and without split tensor are the same.

**4k input results:**
```shell
As the truth came into focus, the man realized that he had been given a second chance at life. He knew that his journey was far from his not alone in the city where he had lived his entire life. The deeper he delved into a stunning picture of a world that had been lost for centuries, a world where he had been hidden in perfect harmony. They discovered artifacts and documents that revealed the truth about their own talents of the city's secrets of the man's own had been hidden in the city's own had been lost in the city's of the man's own had been lost in the city's of the man's of the city's lost in the man's lost in the city's of the man's lost in the city's of the man's lost in the city's of the man's lost in the city's of the man's lost in the city's of the man's lost in the city's of the man's of the lost in the city's of the man's of the city's of the lost in the man's of the city's lost in the man's of the city's of the man's of the lost in the city's of the man's of the city's of the lost in the man's of the city's of the man's of the lost in the of the city's of the man's of the city's of the man's of the city's of the man's of the city's of the man's of the lost of the man's of the city's of
```

**6k input results:**
```shell
Љ
Љ
Љ
Љ
Љ
Љ
Љ
Љ
Љ
Љ.Љ.ЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉ.Љ.Љ
Љ
Љ
Љ
Љ
Љ
Љ
Љ.Љ
Љ.ЉЉЉ.Љ.Љ.Љ.Љ.Љ.Љ.ЉЉЉЉЉЉЉ.Љ.Љ.Љ.Љ.Љ.Љ.Љ.Љ.Љ.ЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉЉ.Љ
```

**8k input results:**
```shell
As he walked, the trees grew taller and closer together, until he was surrounded by a canopy of leaves that blocked out most of the light. He felt a sudden sense of unease, as if he was being watched. He tried to shake off the feeling<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk>
```