### PR TITLE
LLM: Fix no return_last_logits running chatglm3

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert_ipex.py
+++ b/python/llm/src/ipex_llm/transformers/convert_ipex.py
@@ -163,7 +163,7 @@ def _ipex_jit(model):
         get_dummy_input(model, return_dict=True)
     )
     if "return_last_logit" in sample_inputs:
-        del sample_inputs["return_last_logit"]
+        sample_inputs["return_last_logit"] = torch.tensor(False)
     with torch.no_grad(), torch.cpu.amp.autocast(
         enabled=True
     ):

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -691,13 +691,21 @@ def speculative_generate(self,
                         past_key_value_len = draft_past_key_values[0][0].shape[2]
                         position_ids = torch.Tensor([[past_key_value_len + step_draft]]).long()
                         position_ids = position_ids[:, :-draft_current_input_ids.size(0)]
-                        draft_output = draft_model.trace_graph(
-                            input_ids=draft_current_input_ids,
-                            attention_mask=draft_attention_mask,
-                            position_ids=position_ids,
-                            return_last_logit=torch.tensor(False),
-                            past_key_values=draft_past_key_values,
-                        )
+                        if self.config.model_type == "chatglm":
+                            draft_output = draft_model.trace_graph(
+                                input_ids=draft_current_input_ids,
+                                attention_mask=draft_attention_mask,
+                                position_ids=position_ids,
+                                return_last_logit=torch.tensor(False),
+                                past_key_values=draft_past_key_values,
+                            )
+                        else:
+                            draft_output = draft_model.trace_graph(
+                                input_ids=draft_current_input_ids,
+                                attention_mask=draft_attention_mask,
+                                position_ids=position_ids,
+                                past_key_values=draft_past_key_values,
+                            )
                     elif self.config.model_type == "baichuan":
                         if self.config.hidden_size == 4096:
                             past_key_value_len = draft_past_key_values[0][0].shape[2]

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -695,6 +695,7 @@ def speculative_generate(self,
                             input_ids=draft_current_input_ids,
                             attention_mask=draft_attention_mask,
                             position_ids=position_ids,
+                            return_last_logit=torch.tensor(False),
                             past_key_values=draft_past_key_values,
                         )
                     elif self.config.model_type == "baichuan":
@@ -820,7 +821,7 @@ def speculative_generate(self,
                     output = self.trace_graph(input_ids=drafted_input_ids,
                                               attention_mask=cur_attention_mask,
                                               position_ids=position_ids,
-                                              # return_last_logit=torch.tensor(False),
+                                              return_last_logit=torch.tensor(False),
                                               past_key_values=past_key_values,)
                 elif "qwen" in self.config.model_type:
                     output = self.trace_graph(input_ids=drafted_input_ids,


### PR DESCRIPTION
## Description
To fix [issue](https://github.com/intel-analytics/ipex-llm/issues/10674). 
[Chatglm3-6b](https://huggingface.co/THUDM/chatglm3-6b/blob/main/modeling_chatglm.py#L920) always set the `return_last_logit=True`. Need to remove it or set it to False.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
