### PR TITLE
Enable optimization for sentence_transformers

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -530,13 +530,13 @@ def _optimize_pre(model):
     try:
         from sentence_transformers.SentenceTransformer import SentenceTransformer
         if isinstance(model, SentenceTransformer):
-            if str(model._modules['0']).strip().split(' ')[-1]=='BertModel':
+            if str(model._modules['0']).strip().split(' ')[-1] == 'BertModel':
                 from ipex_llm.transformers.models.bert import merge_qkv
                 model.apply(merge_qkv)
                 return model
     except ModuleNotFoundError:
         pass
-    
+
     from transformers.modeling_utils import PreTrainedModel
     # All huggingface format models are inherited from `PreTrainedModel`
     if not isinstance(model, PreTrainedModel):
@@ -806,7 +806,7 @@ def _optimize_post(model, lightweight_bmm=False):
     try:
         from sentence_transformers.SentenceTransformer import SentenceTransformer
         if isinstance(model, SentenceTransformer):
-            if str(model._modules['0']).strip().split(' ')[-1]=='BertModel':
+            if str(model._modules['0']).strip().split(' ')[-1] == 'BertModel':
                 modeling_module_name = model._modules['0'].auto_model.__class__.__module__
                 module = importlib.import_module(modeling_module_name)
                 from ipex_llm.transformers.models.bert import self_attention_forward


### PR DESCRIPTION
Currently embedding models loaded by using `SentenceTransformer` can't be optimized since they are not HuggingFace `PreTrainedModel`. We can enable optimization separately for these models at the beginning of `_optimize_pre` and `_optimize_post`