### PR TITLE
LLM: optimize llama natvie sdp for split qkv tensor

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1371,8 +1371,8 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
     idx = 0
     for q, k, v in zip(query_split, key_split, value_split):
         attn_weights_split = torch.matmul(q, k) / math.sqrt(head_dim)
-        block_real_size = attn_weights_split.size(1)
-        attn_weights_split_size = (bsz, block_real_size, q_len, kv_seq_len)
+        block_actual_size = attn_weights_split.size(1)
+        attn_weights_split_size = (bsz, block_actual_size, q_len, kv_seq_len)
         if attn_weights_split.size() != attn_weights_split_size:
             invalidInputError(False,
                               f"Splitted attention weights should be of size "
@@ -1387,8 +1387,8 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
             attn_weights_split = attn_weights_split + attention_mask
         attn_weights_split = nn.functional.softmax(attn_weights_split, dim=-1)
         attn_weights_split = torch.matmul(attn_weights_split, v)
-        attn_output[:, idx:idx+block_real_size, :, :] = attn_weights_split
-        idx = idx + block_real_size
+        attn_output[:, idx:idx+block_actual_size, :, :] = attn_weights_split
+        idx = idx + block_actual_size
     return attn_output, None
 
 

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1372,7 +1372,8 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
     idx = 0
     for q, k, v in zip(query_split, key_split, value_split):
         attn_weights_split = torch.matmul(q, k) / math.sqrt(head_dim)
-        attn_weights_split_size = (bsz, block_size, q_len, kv_seq_len)
+        block_real_size = attn_weights_split.size(1)
+        attn_weights_split_size = (bsz, block_real_size, q_len, kv_seq_len)
         if attn_weights_split.size() != attn_weights_split_size:
             invalidInputError(False,
                               f"Splitted attention weights should be of size "
@@ -1387,8 +1388,8 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
             attn_weights_split = attn_weights_split + attention_mask
         attn_weights_split = nn.functional.softmax(attn_weights_split, dim=-1)
         attn_weights_split = torch.matmul(attn_weights_split, v)
-        attn_output[:,idx:idx+attn_weights_split.size(1),:,:] = attn_weights_split
-        idx = idx + attn_weights_split.size(1)
+        attn_output[:,idx:idx+block_real_size,:,:] = attn_weights_split
+        idx = idx + block_real_size
     return attn_output, None
 
 

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1387,7 +1387,7 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
             attn_weights_split = attn_weights_split + attention_mask
         attn_weights_split = nn.functional.softmax(attn_weights_split, dim=-1)
         attn_weights_split = torch.matmul(attn_weights_split, v)
-        attn_output[:,idx:idx+block_real_size,:,:] = attn_weights_split
+        attn_output[:, idx:idx+block_real_size, :, :] = attn_weights_split
         idx = idx + block_real_size
     return attn_output, None
 


### PR DESCRIPTION
## Description

This PR is to optimize llama native sdp for split qkv tensor.

- Change block size from 16 to 8, which will lead to lower peak memory usage and slightly latency impact:
  ```shell
  # block size = 16
  0,togethercomputer/Llama-2-7B-32K-Instruct,5006.55,20.98,0.0,8192-512,1,8192-512,1,sym_int4,N/A,6.81,10.1015625,N/A
  # block size = 8
  0,togethercomputer/Llama-2-7B-32K-Instruct,5021.24,21.03,0.0,8192-512,1,8192-512,1,sym_int4,N/A,6.54,9.7578125,N/A
  ```
- Apply for `attn_output` space in advance to avoid memory peaks during `concat`.