### PR TITLE
LLM: add `enable_xetla` parameter for optimize_model API

### DIFF
--- a/python/llm/src/ipex_llm/optimize.py
+++ b/python/llm/src/ipex_llm/optimize.py
@@ -253,7 +253,8 @@ def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_
                                  optimize_model=optimize_llm,
                                  modules_to_not_convert=modules_to_not_convert,
                                  cpu_embedding=cpu_embedding,
-                                 lightweight_bmm=lightweight_bmm)
+                                 lightweight_bmm=lightweight_bmm,
+                                 enable_xetla=kwargs.pop("enable_xetla", False))
     # add save_low_bit to pretrained model dynamically
     import types
     model._bigdl_config = dict()


### PR DESCRIPTION
## Description

Add `enable_xetla` parameter for optimize_model API to easily apply fp8 xelta

### 4. How to test?
- [x] Unit test
- [x] Local test
