### PR TITLE
LLM: fix qwen AutoTP

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -617,7 +617,8 @@ def _optimize_pre(model):
             if "QWenAttention" in module.__class__.__name__:
                 c_attn_weight = module.c_attn.weight.data
                 c_attn_bias = module.c_attn.bias.data
-                projection_size = module.projection_size
+                # Compatible with AutoTP case
+                projection_size = c_attn_weight.shape[0] // 3
                 hid_size = module.hidden_size
                 with init_empty_weights():
                     q_proj = torch.nn.Linear(hid_size, projection_size)


### PR DESCRIPTION
## Description

Background: https://github.com/intel-analytics/ipex-llm/issues/10763

There exists shape error when run Qwen-7b or Qwen-14b using AutoTP.
The root cause is our `split_qkv_proj_func` not compatible with deepspeed splitting (https://github.com/microsoft/DeepSpeed/pull/4902/files).

Take Qwen-14b for example, after deepspeed splitting, the shape of `c_attn_weight` is [7680, 5120], but still use `projection_size=5120` to split q/k/v.

So change the `projection_size` to fix.

### 4. How to test?
- [x] Unit test
- [x] Local test
