### PR TITLE
LLM：Fix moe indexs error on cpu

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/mixtral.py
+++ b/python/llm/src/ipex_llm/transformers/models/mixtral.py
@@ -102,7 +102,7 @@ def mixtral_moeblock_forward(self,
                 final_hidden_states = expert_layer(hidden_states, weight)
             else:
                 final_hidden_states = final_hidden_states + expert_layer(hidden_states, weight)
-    elif bs < 256:
+    elif bs < 256 and hidden_states.device.type == 'xpu':
         final_hidden_states = torch.zeros((batch_size * sequence_length, hidden_dim),
                                           dtype=hidden_states.dtype, device=hidden_states.device)
         import linear_q4_0

--- a/python/llm/src/ipex_llm/transformers/models/qwen2_moe.py
+++ b/python/llm/src/ipex_llm/transformers/models/qwen2_moe.py
@@ -567,7 +567,7 @@ def qwen2moe_moeblock_forward(self, hidden_states: torch.Tensor):
                 final_hidden_states = expert_layer(hidden_states) * weight
             else:
                 final_hidden_states = final_hidden_states + expert_layer(hidden_states) * weight
-    elif bs < 256:
+    elif bs < 256 and hidden_states.device.type == 'xpu':
         final_hidden_states = torch.zeros((batch_size * sequence_length, hidden_dim),
                                           dtype=hidden_states.dtype, device=hidden_states.device)
         import linear_q4_0


### PR DESCRIPTION
## Description
Fix moe indexs error `ModuleNotFoundError: No module named 'linear_q4_0'` on cpu running 32-32 or batch_size > 1.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
