### PR TITLE
Updated importing of top_k_top_p_filtering

### DIFF
--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -36,10 +36,10 @@ if version.parse(trans_version) >= version.parse("4.39.0"):
     try:
         from trl.core import top_k_top_p_filtering
     except ModuleNotFoundError:
-        log4Error.invalidInputError(False, "For transformers version >=4.39.0, please pip install trl")
+        log4Error.invalidInputError(False, "For transformers version >= 4.39.0, pip install trl")
 else:
     from transformers import top_k_top_p_filtering
-    
+
 from ipex_llm.utils.common import invalidInputError
 from transformers.modeling_outputs import CausalLMOutputWithPast
 

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -27,8 +27,16 @@ import logging
 import transformers
 from packaging import version
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
-from transformers import top_k_top_p_filtering, GenerationConfig, \
+from transformers import GenerationConfig, \
     LogitsProcessorList, StoppingCriteriaList
+trans_version = transformers.__version__
+if version.parse(trans_version) >= version.parse("4.39.0"):
+    try:
+        from trl.core import top_k_top_p_filtering
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("pip install trl")
+else:
+    from transformers import top_k_top_p_filtering
 from ipex_llm.utils.common import invalidInputError
 from transformers.modeling_outputs import CausalLMOutputWithPast
 

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -29,14 +29,17 @@ from packaging import version
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 from transformers import GenerationConfig, \
     LogitsProcessorList, StoppingCriteriaList
+from ipex_llm.utils.common import log4Error
+
 trans_version = transformers.__version__
 if version.parse(trans_version) >= version.parse("4.39.0"):
     try:
         from trl.core import top_k_top_p_filtering
     except ModuleNotFoundError:
-        raise ModuleNotFoundError("pip install trl")
+        log4Error.invalidInputError(False, "For transformers version >=4.39.0, please pip install trl")
 else:
     from transformers import top_k_top_p_filtering
+    
 from ipex_llm.utils.common import invalidInputError
 from transformers.modeling_outputs import CausalLMOutputWithPast
 


### PR DESCRIPTION
In `transformers>=4.39.0`, the `top_k_top_p_filtering` function has been deprecated and has been moved to the hugging face package `trl`. Thus for versions` >= 4.39.0`, we need to import this function from `trl`