### PR TITLE
LLM: add mixed quantization for lm_head

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -91,11 +91,13 @@ if is_auto_awq_available():
     from ipex_llm.transformers.awq.linear import WQLinear_GEMM
     from transformers.utils.quantization_config import AwqBackendPackingMethod
 
+
 def is_lm_head(name, model_config, out_features):
     if name == "lm_head" or getattr(model_config, "vocab_size", None) == out_features:
         return True
     else:
         return False
+
 
 def is_linear_module(module):
 

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -298,8 +298,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                     cur_qtype, cur_imatrix = get_cur_qtype_and_imatrix(qtype,
                                                                        full_module_name,
                                                                        imatrix_data,
-                                                                       model_config,
-                                                                       mixed_precision)
+                                                                       model_config)
                     # mixed precison for lm_head
                     if mixed_precision and is_lm_head(name, model_config, out_features):
                         if cur_qtype in [ggml_tensor_qtype["sym_int4"],

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -140,6 +140,9 @@ class _BaseAutoModelClass:
             specify the model hub. Default to be ``'huggingface'``.
         :param embedding_qtype: str value, options are ``'q2_k'`` now. Default to be None.
             Relevant low bit optimizations will be applied to nn.Embedding layer.
+        :param mixed_quantization: boolean value, Whether to use mixed precision quantization.
+            Default to be False. If set to True, we will use sym_int8 for lm_head when
+            load_in_low_bit is sym_int4 or asym_int4.
         :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
@@ -394,6 +397,7 @@ class _BaseAutoModelClass:
         quant_config = kwargs.pop("quantization_config", None)
         imatrix_data = kwargs.pop("imatrix_data", None)
         embedding_qtype = kwargs.pop("embedding_qtype", None)
+        mixed_quantization = kwargs.pop("mixed_quantization", False)
         if embedding_qtype is not None:
             embedding_qtype = ggml_tensor_qtype[embedding_qtype]
         enable_xetla = kwargs.pop("enable_xetla", False)
@@ -463,7 +467,8 @@ class _BaseAutoModelClass:
                                      torch_dtype=kwargs.get("torch_dtype", 'auto'),
                                      imatrix_data=imatrix_data,
                                      embedding_qtype=embedding_qtype,
-                                     enable_xetla=enable_xetla,)
+                                     enable_xetla=enable_xetla,
+                                     mixed_quantization=mixed_quantization)
         model.config.update({"bigdl_transformers_low_bit": q_k})
 
         # enable tie_word_embeddings for MPT

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -140,7 +140,7 @@ class _BaseAutoModelClass:
             specify the model hub. Default to be ``'huggingface'``.
         :param embedding_qtype: str value, options are ``'q2_k'`` now. Default to be None.
             Relevant low bit optimizations will be applied to nn.Embedding layer.
-        :param mixed_quantization: boolean value, Whether to use mixed precision quantization.
+        :param mixed_precision: boolean value, Whether to use mixed precision quantization.
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
         :return: a model instance
@@ -397,7 +397,7 @@ class _BaseAutoModelClass:
         quant_config = kwargs.pop("quantization_config", None)
         imatrix_data = kwargs.pop("imatrix_data", None)
         embedding_qtype = kwargs.pop("embedding_qtype", None)
-        mixed_quantization = kwargs.pop("mixed_quantization", False)
+        mixed_precision = kwargs.pop("mixed_precision", False)
         if embedding_qtype is not None:
             embedding_qtype = ggml_tensor_qtype[embedding_qtype]
         enable_xetla = kwargs.pop("enable_xetla", False)
@@ -468,7 +468,7 @@ class _BaseAutoModelClass:
                                      imatrix_data=imatrix_data,
                                      embedding_qtype=embedding_qtype,
                                      enable_xetla=enable_xetla,
-                                     mixed_quantization=mixed_quantization)
+                                     mixed_precision=mixed_precision)
         model.config.update({"bigdl_transformers_low_bit": q_k})
 
         # enable tie_word_embeddings for MPT

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -269,8 +269,7 @@ def module_name_process(full_module_name):
     return new_module_name, layer, cur_module
 
 
-def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_config=None,
-                              mixed_precision=False):
+def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_config=None):
     cur_qtype = qtype
     if model_config is not None:
         model_type = getattr(model_config, "model_type", None)

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -269,7 +269,8 @@ def module_name_process(full_module_name):
     return new_module_name, layer, cur_module
 
 
-def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_config=None):
+def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data, model_config=None,
+                              mixed_precision=False):
     cur_qtype = qtype
     if model_config is not None:
         model_type = getattr(model_config, "model_type", None)


### PR DESCRIPTION
## Description


### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/1286
Based on our experiment, using sym_int8 for lm_head can provide better accuracy.
In this PR, we just add a new `mixed_precision` parameter to do this.
In the future, we can add more mixed quantization stretagy.

### 2. User API changes
add new `mixed_precision` parameter.
```python
model = AutoModelForCausalLM.from_pretrained(model_path,
                                             load_in_low_bit="sym_int4",
                                             torch_dtype=torch.float16,
                                             optimize_model=True,
                                             trust_remote_code=True,
                                             use_cache=True,
                                             mixed_precision=True)
```

### 3. Summary of the change 

- add new `mixed_precision` parameter.
- use sym_int8 for lm_head when set mixed_precision=True and load_in_low_bit=sym_int4/asym_int4.

### 4. How to test?
- [x] Local test
- [ ] Unit test
