### PR TITLE
Ollama quickstart update

### DIFF
--- a/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
@@ -157,7 +157,6 @@ Ollama supports importing GGUF models in the Modelfile, for example, suppose you
 ```bash
 FROM ./mistral-7b-instruct-v0.1.Q4_K_M.gguf
 TEMPLATE [INST] {{ .Prompt }} [/INST]
-PARAMETER num_gpu 999
 PARAMETER num_predict 64
 ```
 

--- a/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
@@ -69,7 +69,7 @@ Launch the Ollama service:
          set ZES_ENABLE_SYSMAN=1
          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 
-         ollama serve
+         ollama.exe serve
 
 ```
 
@@ -96,6 +96,20 @@ Keep the Ollama service on and open another terminal and run `./ollama pull <mod
 
 ### 5 Using Ollama
 
+To make sure all layers of your model are runnng on Intel GPU, please set the environment variable by running the following command:
+```eval_rst
+.. tabs::
+   .. tab:: Linux
+
+      .. code-block:: bash
+         export OLLAMA_NUM_GPU=999
+
+   .. tab:: Windows
+
+      .. code-block:: bash
+         set OLLAMA_NUM_GPU=999
+```
+
 #### Using Curl 
 
 Using `curl` is the easiest way to verify the API service and model. Execute the following commands in a terminal. **Replace the <model_name> with your pulled 
@@ -111,8 +125,7 @@ model**, e.g. `dolphin-phi`.
          { 
             "model": "<model_name>", 
             "prompt": "Why is the sky blue?", 
-            "stream": false,
-            "options":{"num_gpu": 999}
+            "stream": false
          }'
 
    .. tab:: Windows
@@ -125,8 +138,7 @@ model**, e.g. `dolphin-phi`.
          {
             \"model\": \"<model_name>\",
             \"prompt\": \"Why is the sky blue?\",
-            \"stream\": false,
-            \"options\":{\"num_gpu\": 999}
+            \"stream\": false
          }"
 
 ```
@@ -135,7 +147,7 @@ model**, e.g. `dolphin-phi`.
 ```eval_rst
 .. note::
 
-  Please don't forget to set ``"options":{"num_gpu": 999}`` to make sure all layers of your model are running on Intel GPU, otherwise, some layers may run on CPU.
+  Please don't forget to set environment variable ``OLLAMA_NUM_GPU``, otherwise, some layers may run on CPU.
 ```
 
 #### Using Ollama Run GGUF models
@@ -152,7 +164,7 @@ PARAMETER num_predict 64
 ```eval_rst
 .. note::
 
-  Please don't forget to set ``PARAMETER num_gpu 999`` to make sure all layers of your model are running on Intel GPU, otherwise, some layers may run on CPU.
+  Please don't forget to set environment variable ``OLLAMA_NUM_GPU``, otherwise, some layers may run on CPU.
 ```
 
 Then you can create the model in Ollama by `ollama create example -f Modelfile` and use `ollama run` to run the model directly on console.
@@ -174,8 +186,8 @@ Then you can create the model in Ollama by `ollama create example -f Modelfile` 
       .. code-block:: bash
 
          set no_proxy=localhost,127.0.0.1
-         ollama create example -f Modelfile
-         ollama run example
+         ollama.exe create example -f Modelfile
+         ollama.exe run example
 
 ```
 

--- a/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
@@ -44,8 +44,23 @@ Activate the `llm-cpp` conda environment and initialize Ollama by executing the 
 
 ### 3 Run Ollama Serve
 
+To run all layers of your model on Intel GPU, please set the environment variable first by running the following command:
+```eval_rst
+.. tabs::
+   .. tab:: Linux
 
-Launch the Ollama service:
+      .. code-block:: bash
+         
+         export OLLAMA_NUM_GPU=999
+
+   .. tab:: Windows
+
+      .. code-block:: bash
+         
+         set OLLAMA_NUM_GPU=999
+```
+
+Then launch the Ollama service:
 
 ```eval_rst
 .. tabs::
@@ -96,20 +111,6 @@ Keep the Ollama service on and open another terminal and run `./ollama pull <mod
 
 ### 5 Using Ollama
 
-To make sure all layers of your model are runnng on Intel GPU, please set the environment variable by running the following command:
-```eval_rst
-.. tabs::
-   .. tab:: Linux
-
-      .. code-block:: bash
-         export OLLAMA_NUM_GPU=999
-
-   .. tab:: Windows
-
-      .. code-block:: bash
-         set OLLAMA_NUM_GPU=999
-```
-
 #### Using Curl 
 
 Using `curl` is the easiest way to verify the API service and model. Execute the following commands in a terminal. **Replace the <model_name> with your pulled 
@@ -144,12 +145,6 @@ model**, e.g. `dolphin-phi`.
 ```
 
 
-```eval_rst
-.. note::
-
-  Please don't forget to set environment variable ``OLLAMA_NUM_GPU``, otherwise, some layers may run on CPU.
-```
-
 #### Using Ollama Run GGUF models
 
 Ollama supports importing GGUF models in the Modelfile, for example, suppose you have downloaded a `mistral-7b-instruct-v0.1.Q4_K_M.gguf` from [Mistral-7B-Instruct-v0.1-GGUF](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/tree/main), then you can create a file named `Modelfile`:
@@ -158,12 +153,6 @@ Ollama supports importing GGUF models in the Modelfile, for example, suppose you
 FROM ./mistral-7b-instruct-v0.1.Q4_K_M.gguf
 TEMPLATE [INST] {{ .Prompt }} [/INST]
 PARAMETER num_predict 64
-```
-
-```eval_rst
-.. note::
-
-  Please don't forget to set environment variable ``OLLAMA_NUM_GPU``, otherwise, some layers may run on CPU.
 ```
 
 Then you can create the model in Ollama by `ollama create example -f Modelfile` and use `ollama run` to run the model directly on console.

--- a/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
@@ -44,30 +44,15 @@ Activate the `llm-cpp` conda environment and initialize Ollama by executing the 
 
 ### 3 Run Ollama Serve
 
-To run all layers of your model on Intel GPU, please set the environment variable first by running the following command:
+You may launch the Ollama service as below:
+
 ```eval_rst
 .. tabs::
    .. tab:: Linux
 
       .. code-block:: bash
-         
+
          export OLLAMA_NUM_GPU=999
-
-   .. tab:: Windows
-
-      .. code-block:: bash
-         
-         set OLLAMA_NUM_GPU=999
-```
-
-Then launch the Ollama service:
-
-```eval_rst
-.. tabs::
-   .. tab:: Linux
-
-      .. code-block:: bash
-
          export no_proxy=localhost,127.0.0.1
          export ZES_ENABLE_SYSMAN=1
          source /opt/intel/oneapi/setvars.sh
@@ -80,6 +65,7 @@ Then launch the Ollama service:
 
       .. code-block:: bash
 
+         set OLLAMA_NUM_GPU=999
          set no_proxy=localhost,127.0.0.1
          set ZES_ENABLE_SYSMAN=1
          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
@@ -89,6 +75,11 @@ Then launch the Ollama service:
 ```
 
 ```eval_rst
+.. note::
+
+  Please set environment variable ``OLLAMA_NUM_GPU`` to ``999`` to make sure all layers of your model are running on Intel GPU, otherwise, some layers may run on CPU.
+```
+
 .. note::
 
   To allow the service to accept connections from all IP addresses, use `OLLAMA_HOST=0.0.0.0 ./ollama serve` instead of just `./ollama serve`.

--- a/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
@@ -69,7 +69,7 @@ Launch the Ollama service:
          set ZES_ENABLE_SYSMAN=1
          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 
-         ollama.exe serve
+         ollama serve
 
 ```
 
@@ -185,8 +185,8 @@ Then you can create the model in Ollama by `ollama create example -f Modelfile` 
       .. code-block:: bash
 
          set no_proxy=localhost,127.0.0.1
-         ollama.exe create example -f Modelfile
-         ollama.exe run example
+         ollama create example -f Modelfile
+         ollama run example
 
 ```
 


### PR DESCRIPTION
## Description

Add `OLLAMA_NUM_GPU` env variables in ollama quickstart,  remove `PARAMETER num_gpu 999` and `"options": {"num_gpu": 999}`.

We will only recommend users to set `OLLAMA_NUM_GPU` to run models on gpu in the future.

### 4. How to test?
- [x] Document test   https://ipex-llm-ollama.readthedocs.io/en/latest/doc/LLM/Quickstart/ollama_quickstart.html