### PR TITLE
Add llama 3 8B and Yi-6B-Chat to igpu nightly perf

### DIFF
--- a/python/llm/test/benchmark/igpu-perf/1024-128.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128.yaml
@@ -6,7 +6,7 @@ repo_id:
   - 'internlm/internlm-chat-7b-8k'
   - 'Qwen/Qwen-7B-Chat'
   - 'BAAI/AquilaChat2-7B'
-  - '01-ai/Yi-6B'
+  # - '01-ai/Yi-6B'
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'WisdomShell/CodeShell-7B-Chat'

--- a/python/llm/test/benchmark/igpu-perf/1024-128_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_437.yaml
@@ -1,5 +1,7 @@
 repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
+  - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - '01-ai/Yi-6B-Chat'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16.yaml
@@ -6,7 +6,7 @@ repo_id:
   - 'internlm/internlm-chat-7b-8k'
   - 'Qwen/Qwen-7B-Chat'
   - 'BAAI/AquilaChat2-7B'
-  - '01-ai/Yi-6B'
+  # - '01-ai/Yi-6B'
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'WisdomShell/CodeShell-7B-Chat'

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_437.yaml
@@ -1,5 +1,7 @@
 repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
+  - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - '01-ai/Yi-6B-Chat'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_loadlowbit.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_loadlowbit.yaml
@@ -6,7 +6,7 @@ repo_id:
   - 'internlm/internlm-chat-7b-8k'
   - 'Qwen/Qwen-7B-Chat'
   - 'BAAI/AquilaChat2-7B'
-  - '01-ai/Yi-6B'
+  # - '01-ai/Yi-6B'
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'WisdomShell/CodeShell-7B-Chat'

--- a/python/llm/test/benchmark/igpu-perf/1024-128_loadlowbit_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_loadlowbit_437.yaml
@@ -1,5 +1,7 @@
 repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
+  - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - '01-ai/Yi-6B-Chat'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/2048-256.yaml
+++ b/python/llm/test/benchmark/igpu-perf/2048-256.yaml
@@ -6,7 +6,7 @@ repo_id:
   - 'internlm/internlm-chat-7b-8k'
   - 'Qwen/Qwen-7B-Chat'
   - 'BAAI/AquilaChat2-7B'
-  - '01-ai/Yi-6B'
+  # - '01-ai/Yi-6B'
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'WisdomShell/CodeShell-7B-Chat'

--- a/python/llm/test/benchmark/igpu-perf/2048-256_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/2048-256_437.yaml
@@ -1,5 +1,7 @@
 repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
+  - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - '01-ai/Yi-6B-Chat'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/32-32.yaml
+++ b/python/llm/test/benchmark/igpu-perf/32-32.yaml
@@ -6,7 +6,7 @@ repo_id:
   - 'internlm/internlm-chat-7b-8k'
   - 'Qwen/Qwen-7B-Chat'
   - 'BAAI/AquilaChat2-7B'
-  - '01-ai/Yi-6B'
+  # - '01-ai/Yi-6B'
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'WisdomShell/CodeShell-7B-Chat'

--- a/python/llm/test/benchmark/igpu-perf/32-32_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/32-32_437.yaml
@@ -1,5 +1,7 @@
 repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
+  - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - '01-ai/Yi-6B-Chat'
 local_model_hub: 'path to your local model hub'
 warm_up: 3
 num_trials: 5


### PR DESCRIPTION
## Description

- Add Llama 3 8B to iGPU nightly test
- Monitor new Yi-6B-Chat model (instead of old Yi-6B) due to https://github.com/analytics-zoo/nano/issues/1279#issuecomment-2063044766
  As [Yi-6B-Chat](https://huggingface.co/01-ai/Yi-6B-Chat) seems to be saved using `transformers 4.35.0`, we choose `transformers 4.37.0` for testing for now, instead of `transformers 4.31.0`