### PR TITLE
LLM: support llama split tensor for long context in transformers>=4.36.

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/chatglm2.py
+++ b/python/llm/src/ipex_llm/transformers/models/chatglm2.py
@@ -258,8 +258,8 @@ def chatglm2_quantized_attention_forward_8eb45c(
             query_split = torch.split(query_layer, block_size, dim=1)
             key_split = torch.split(key, block_size, dim=1)
             value_split = torch.split(value, block_size, dim=1)
-            context_layer = torch.empty(batch_size, n_head,
-                                        seq_len, head_dim).to(query_layer.device)
+            context_layer = torch.empty(batch_size, n_head, seq_len,
+                                        head_dim, dtype=key.dtype).to(query_layer.device)
             idx = 0
             for q, k, v in zip(query_split, key_split, value_split):
                 if attention_mask is None:
@@ -543,7 +543,7 @@ def core_attn_forward_8eb45c(query_layer, key_layer, value_layer, attention_mask
                 value_split = torch.split(value_layer, block_size, dim=1)
                 batch_size, n_head, seq_len, head_dim = query_layer.shape
                 context_layer = torch.empty(batch_size, n_head, seq_len,
-                                            head_dim).to(query_layer.device).to(key_layer.dtype)
+                                            head_dim, dtype=key_layer.dtype).to(query_layer.device)
                 idx = 0
                 for q, k, v in zip(query_split, key_split, value_split):
                     result = F.scaled_dot_product_attention(q, k, v, is_causal=True).to(k.dtype)

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1034,7 +1034,7 @@ def llama_attention_forward_4_36_quantized(
                                                          bsz, q_len, kv_seq_len, self.head_dim,
                                                          self.num_heads)
         else:
-            attn_weights = torch.matmul(query_states, repeated_key_states\
+            attn_weights = torch.matmul(query_states, repeated_key_states
                                         .transpose(2, 3)) / math.sqrt(self.head_dim)
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1034,8 +1034,8 @@ def llama_attention_forward_4_36_quantized(
                                                          bsz, q_len, kv_seq_len, self.head_dim,
                                                          self.num_heads)
         else:
-            attn_weights = torch.matmul(query_states, repeated_key_states.\
-                                        transpose(2, 3)) / math.sqrt(self.head_dim)
+            attn_weights = torch.matmul(query_states, repeated_key_states\
+                                        .transpose(2, 3)) / math.sqrt(self.head_dim)
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 invalidInputError(

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1029,13 +1029,15 @@ def llama_attention_forward_4_36_quantized(
         repeated_key_states = repeat_kv(key_states, self.num_key_value_groups)
         repeated_value_states = repeat_kv(value_states, self.num_key_value_groups)
         if should_split_qkv_tensor(query_states, output_attentions):
-            attn_output, _ = native_sdp_split_qkv_tensor(query_states, repeated_key_states, 
+            attn_output, _ = native_sdp_split_qkv_tensor(query_states, repeated_key_states,
                                                          repeated_value_states, attention_mask,
-                                                         bsz, q_len, kv_seq_len,self.head_dim,
+                                                         bsz, q_len, kv_seq_len, self.head_dim,
                                                          self.num_heads)
         else:
-            attn_weights = torch.matmul(query_states,
-                                        repeated_key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+            attn_weights = torch.matmul(
+                query_states,
+                repeated_key_states.transpose(2, 3)
+                ) / math.sqrt(self.head_dim)
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 invalidInputError(
@@ -1061,7 +1063,7 @@ def llama_attention_forward_4_36_quantized(
             else:
                 # upcast attention to fp32
                 attn_weights = nn.functional.softmax(attn_weights, dim=-1,
-                                                    dtype=torch.float32).to(query_states.dtype)
+                                                     dtype=torch.float32).to(query_states.dtype)
             attn_output = torch.matmul(attn_weights, repeated_value_states)
         if use_cache:
             cache_kwargs = None

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1034,10 +1034,8 @@ def llama_attention_forward_4_36_quantized(
                                                          bsz, q_len, kv_seq_len, self.head_dim,
                                                          self.num_heads)
         else:
-            attn_weights = torch.matmul(
-                query_states,
-                repeated_key_states.transpose(2, 3)
-            ) / math.sqrt(self.head_dim)
+            attn_weights = torch.matmul(query_states, repeated_key_states.\
+                                        transpose(2, 3)) / math.sqrt(self.head_dim)
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 invalidInputError(

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1422,7 +1422,7 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
     query_split = torch.split(query.to(key.dtype), block_size, dim=1)
     key_split = torch.split(key.transpose(2, 3), block_size, dim=1)
     value_split = torch.split(value, block_size, dim=1)
-    attn_output = torch.empty(bsz, num_heads, q_len, head_dim, dtype=key.dtype).to(query.device)
+    attn_output = torch.empty(bsz, num_heads, q_len, head_dim).to(query.device)
     idx = 0
     for q, k, v in zip(query_split, key_split, value_split):
         attn_weights_split = torch.matmul(q, k) / math.sqrt(head_dim)
@@ -1444,7 +1444,7 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask,
         attn_weights_split = torch.matmul(attn_weights_split, v)
         attn_output[:, idx:idx+block_actual_size, :, :] = attn_weights_split
         idx = idx + block_actual_size
-    return attn_output, None
+    return attn_output.to(key.dtype), None
 
 
 def llama_model_selective_batching_forward_4_31(

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1037,7 +1037,7 @@ def llama_attention_forward_4_36_quantized(
             attn_weights = torch.matmul(
                 query_states,
                 repeated_key_states.transpose(2, 3)
-                ) / math.sqrt(self.head_dim)
+            ) / math.sqrt(self.head_dim)
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 invalidInputError(


### PR DESCRIPTION
## Description

This PR is to support llama split tensor for long context in transformers>=4.36

### Test results on ARC

- perf test
```shell
0,meta-llama/llama3-8b-instruction-hf,7854.15,17.69,0.0,8192-512,1,8167-512,1,sym_int4,False,7.82,12.369140625,N/A
```
- output result:
```shell
The Court in that case did not suggest that the Superintendent's discretion was 'completely unfettered.' [11] The Court in Meachum v. Fano, 427 U. S. 215 (1976), held that a state-created liberty interest is not implicated when a prison regulation authorizes the transfer of a prisoner from one institution to another 'for whatever reason or for no reason at all.' [12] The Court in Vitek v. Jones, 445 U. S. 480 (1980), held that a state-created liberty interest is implicated when a prison regulation authorizes the transfer of a prisoner from a prison to a mental hospital 'for whatever reason or for no reason at all.' [13] The Court in Meachum v. Fano, 427 U. S. 215 (1976), held that a state-created liberty interest is not implicated when a prison regulation authorizes the transfer of a prisoner from one institution to another 'for whatever reason or for no reason at all.' [14] The Court in Vitek v. Jones, 445 U. S. 480 (1980), held that a state-created liberty interest is implicated when a prison regulation authorizes the transfer of a prisoner from a prison to a mental hospital 'for whatever reason or for no reason at all.' [15] The Court in Meachum v. Fano, 427 U. S. 215 (1976), held that a state-created liberty interest is not implicated when a prison regulation authorizes the transfer of a prisoner from one institution to another 'for whatever reason or for no reason at all.' [16] The Court in Vitek v. Jones, 445 U. S. 480 (1980), held that a state-created liberty interest is implicated when a prison regulation authorizes the transfer of a prisoner from a prison to a mental hospital 'for whatever reason or for no reason at all.' [17] The Court in Meachum v. Fano, 427 U. S. 215 (1976), held that a state-created liberty interest is not implicated when a prison regulation authorizes the transfer of a prisoner from one institution to another 'for
```