### PR TITLE
fix ollama quickstart

### DIFF
--- a/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/ollama_quickstart.md
@@ -81,6 +81,7 @@ You may launch the Ollama service as below:
   Please set environment variable ``OLLAMA_NUM_GPU`` to ``999`` to make sure all layers of your model are running on Intel GPU, otherwise, some layers may run on CPU.
 ```
 
+```eval_rst
 .. note::
 
   To allow the service to accept connections from all IP addresses, use `OLLAMA_HOST=0.0.0.0 ./ollama serve` instead of just `./ollama serve`.


### PR DESCRIPTION
## Description


### 1. Why the change?

fix ollama QuickStart caused by missing `eval_rst`
![image](https://github.com/intel-analytics/ipex-llm/assets/105281011/da0f07a2-1318-4231-8723-d1f94f28fa89)
