### PR TITLE
Fix speculative decoding bug

### DIFF
--- a/python/llm/example/CPU/Speculative-Decoding/baichuan2/speculative.py
+++ b/python/llm/example/CPU/Speculative-Decoding/baichuan2/speculative.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
                         help='Prompt to infer')
     parser.add_argument('--precision', type=str, default='bf16',
                         help='Main model Precision')
-    parser.add_argument('--n_predict', type=int, default=128,
+    parser.add_argument('--n-predict', type=int, default=128,
                         help='Max tokens to predict')
     parser.add_argument('--max-draft', type=int, default=8,
                         help='Max draft')

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -100,6 +100,12 @@ def generate(
                                          draft_model=self.draft_model,
                                          **new_speculative_kwargs)
     else:
+        # When `draft_model` is false, these attributes
+        # ralted to speculative decoding should be removed
+        for var in ['max_step_draft', 'th_stop_draft', 'hf_adjust',
+                    'auto_th_stop_draft', 'auto_parameters', 'min_step_draft',
+                    'th_batch_num']:
+            value = kwargs.pop(var, None)
         return original_generate(self,
                                  inputs=inputs,
                                  generation_config=generation_config,

--- a/python/llm/src/ipex_llm/transformers/speculative.py
+++ b/python/llm/src/ipex_llm/transformers/speculative.py
@@ -74,8 +74,7 @@ def generate(
             for var in ['max_step_draft', 'th_stop_draft', 'hf_adjust',
                         'auto_th_stop_draft', 'auto_parameters', 'min_step_draft',
                         'th_batch_num']:
-                value = kwargs.pop(var, None)
-            del self.draft_model
+                kwargs.pop(var, None)
             return original_generate(self,
                                      inputs=inputs,
                                      generation_config=generation_config,
@@ -101,11 +100,11 @@ def generate(
                                          **new_speculative_kwargs)
     else:
         # When `draft_model` is false, these attributes
-        # ralted to speculative decoding should be removed
+        # related to speculative decoding should be removed
         for var in ['max_step_draft', 'th_stop_draft', 'hf_adjust',
                     'auto_th_stop_draft', 'auto_parameters', 'min_step_draft',
                     'th_batch_num']:
-            value = kwargs.pop(var, None)
+            kwargs.pop(var, None)
         return original_generate(self,
                                  inputs=inputs,
                                  generation_config=generation_config,


### PR DESCRIPTION
## Description

IPEX_CPU optimized models have issues for speculative decoding with short prompts, and in warmup, `draf_model` will be deleted, so we should remove these attributes in `else

### 4. How to test?
- [x] Application test

