### PR TITLE
LLM: Enable batch generate (world_size>1) in Deepspeed-AutoTP-FastAPI example

### DIFF
--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/run_llama2_7b_chat_hf_arc_2_card.sh
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/run_llama2_7b_chat_hf_arc_2_card.sh
@@ -31,6 +31,7 @@ export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
 export TORCH_LLM_ALLREDUCE=0
 
 export WORLD_SIZE=2
+export MAX_NUM_SEQS=16
 
 mpirun -np $NUM_GPUS --prepend-rank \
         python serving.py --repo-id-or-model-path YOUR_REPO_ID_OR_MODEL_PATH --low-bit 'sym_int4' --port 8000

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/run_llama2_7b_chat_hf_arc_2_card.sh
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/run_llama2_7b_chat_hf_arc_2_card.sh
@@ -30,6 +30,8 @@ export USE_XETLA=OFF
 export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
 export TORCH_LLM_ALLREDUCE=0
 
+export WORLD_SIZE=2
+
 mpirun -np $NUM_GPUS --prepend-rank \
         python serving.py --repo-id-or-model-path YOUR_REPO_ID_OR_MODEL_PATH --low-bit 'sym_int4' --port 8000
 

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
@@ -77,7 +77,7 @@ def load_model(model_path, low_bit):
 
     model = deepspeed.init_inference(
         model,
-        mp_size=1,
+        tensor_parallel={"tp_size": world_size},
         dtype=torch.bfloat16,
         replace_method="auto",
     )

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
@@ -135,7 +135,7 @@ result_dict: Dict[str, str] = {}
 async def generate(prompt_request: PromptRequest):
     request_id = str(uuid.uuid4())
     await request_queue.put((request_id, prompt_request))
-    while True:  # 轮询获取结果
+    while True:
         await asyncio.sleep(0.1)
         if request_id in result_dict:
             output_str = result_dict.pop(request_id)

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
@@ -77,7 +77,7 @@ def load_model(model_path, low_bit):
 
     model = deepspeed.init_inference(
         model,
-        mp_size=world_size,
+        mp_size=1,
         dtype=torch.bfloat16,
         replace_method="auto",
     )

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
@@ -77,7 +77,7 @@ def load_model(model_path, low_bit):
 
     model = deepspeed.init_inference(
         model,
-        mp_size=1,
+        mp_size=world_size,
         dtype=torch.bfloat16,
         replace_method="auto",
     )

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
@@ -102,7 +102,7 @@ def load_model(model_path, low_bit):
     init_distributed()
 
     # Load tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True, padding_side='left')
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
@@ -181,17 +181,6 @@ async def process_requests():
 async def startup_event():
     asyncio.create_task(process_requests())
 
-# @app.post("/generate/")
-# async def generate(prompt_request: PromptRequest):
-#     if local_rank == 0:
-#         object_list = [prompt_request]
-#         dist.broadcast_object_list(object_list, src=0)
-#         start_time = time.time()
-#         output = generate_text(object_list[0].prompt, object_list[0].n_predict)
-#         generate_time = time.time() - start_time
-#         output = output.cpu()
-#         output_str = tokenizer.decode(output[0], skip_special_tokens=True)
-#         return {"generated_text": output_str, "generate_time": f'{generate_time:.3f}s'}
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Predict Tokens using fastapi by leveraging DeepSpeed-AutoTP')

--- a/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP-FastAPI/serving.py
@@ -107,7 +107,7 @@ def load_model(model_path, low_bit):
         tokenizer.pad_token = tokenizer.eos_token
 
 def generate_text(prompt: List[str], n_predict = 32):
-    while prompt[-1] is None:
+    while prompt[-1] == "":
         prompt = prompt[:-1]
     if isinstance(n_predict, list):
         n_predict = max(n_predict)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Enable batch generate (world_size>1) in Deepspeed-AutoTP-FastAPI example.
Use `request_queue` and `result_dict` to store and return requests' result.