### PR TITLE
LLM: Fix  bigdl_ipex_int 8 warning

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert_ipex.py
+++ b/python/llm/src/ipex_llm/transformers/convert_ipex.py
@@ -138,7 +138,7 @@ def _ipex_optimize_model(model, rms_classes, qtype):
         }
         qconfig = ipex.quantization.get_weight_only_quant_qconfig_mapping(
             weight_dtype=torch.qint8,  # INT8
-            lowp_mode=ipex.quantization.WoqLowpMode.INT8,
+            lowp_mode=ipex.quantization.WoqLowpMode.BF16,
             act_quant_mode=act_quant_mode_dict["PER_IC_BLOCK"],
             group_size=-1,
         )


### PR DESCRIPTION
## Description
 Fix  bigdl_ipex_int 8 warning.
Update it first and remove warning here.
https://github.com/intel/intel-extension-for-pytorch/blob/b291a8150a5bb77c327767b568af3ccff97e8748/intel_extension_for_pytorch/nn/modules/weight_only_quantization.py#L102
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
