### PR TITLE
Fix apt install oneapi scripts

### DIFF
--- a/docs/readthedocs/source/doc/LLM/Overview/install_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Overview/install_gpu.md
@@ -240,8 +240,11 @@ IPEX-LLM GPU support on Linux has been verified on:
                   intel-oneapi-mpi=2021.11.0-49493 \
                   intel-oneapi-mpi-devel=2021.11.0-49493 \
                   intel-oneapi-dal=2024.0.1-25 \
+                  intel-oneapi-dal-devel=2024.0.1-25 \
                   intel-oneapi-ippcp=2021.9.1-5 \
+                  intel-oneapi-ippcp-devel=2021.9.1-5 \
                   intel-oneapi-ipp=2021.10.1-13 \
+                  intel-oneapi-ipp-devel=2021.10.1-13 \
                   intel-oneapi-tlt=2024.0.0-352 \
                   intel-oneapi-ccl=2021.11.2-5 \
                   intel-oneapi-ccl-devel=2021.11.2-5 \

--- a/docs/readthedocs/source/doc/LLM/Overview/install_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Overview/install_gpu.md
@@ -236,6 +236,7 @@ IPEX-LLM GPU support on Linux has been verified on:
                   intel-oneapi-compiler-dpcpp-cpp=2024.0.2-49895 \
                   intel-oneapi-dpcpp-ct=2024.0.0-49381 \
                   intel-oneapi-mkl=2024.0.0-49656 \
+                  intel-oneapi-mkl-devel=2024.0.0-49656 \
                   intel-oneapi-mpi=2021.11.0-49493 \
                   intel-oneapi-mpi-devel=2021.11.0-49493 \
                   intel-oneapi-dal=2024.0.1-25 \

--- a/docs/readthedocs/source/doc/LLM/Overview/install_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Overview/install_gpu.md
@@ -215,6 +215,47 @@ IPEX-LLM GPU support on Linux has been verified on:
       Intel® oneAPI Base Toolkit 2024.0 installation methods:
 
       .. tabs::
+
+         .. tab:: APT installer
+
+            Step 1: Set up repository
+
+            .. code-block:: bash
+
+               wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+               echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+               sudo apt update
+
+            Step 2: Install the package
+
+            .. code-block:: bash
+
+               sudo apt install intel-oneapi-common-vars=2024.0.0-49406 \
+                  intel-oneapi-common-oneapi-vars=2024.0.0-49406 \
+                  intel-oneapi-diagnostics-utility=2024.0.0-49093 \
+                  intel-oneapi-compiler-dpcpp-cpp=2024.0.2-49895 \
+                  intel-oneapi-dpcpp-ct=2024.0.0-49381 \
+                  intel-oneapi-mkl=2024.0.0-49656 \
+                  intel-oneapi-mpi=2021.11.0-49493 \
+                  intel-oneapi-mpi-devel=2021.11.0-49493 \
+                  intel-oneapi-dal=2024.0.1-25 \
+                  intel-oneapi-ippcp=2021.9.1-5 \
+                  intel-oneapi-ipp=2021.10.1-13 \
+                  intel-oneapi-tlt=2024.0.0-352 \
+                  intel-oneapi-ccl=2021.11.2-5 \
+                  intel-oneapi-ccl-devel=2021.11.2-5 \
+                  intel-oneapi-dnnl-devel=2024.0.0-49521 \
+                  intel-oneapi-dnnl=2024.0.0-49521 \
+                  intel-oneapi-tcm-1.0=1.0.0-435
+
+            .. note::
+
+               You can uninstall the package by running the following command:
+
+               .. code-block:: bash
+               
+                  sudo apt autoremove intel-oneapi-common-vars
+
          .. tab:: PIP installer
 
             Step 1: Install oneAPI in a user-defined folder, e.g., ``~/intel/oneapi``.
@@ -247,30 +288,6 @@ IPEX-LLM GPU support on Linux has been verified on:
                
                   rm -r ~/intel/oneapi
                   conda env config vars unset LD_LIBRARY_PATH -n llm
-
-         .. tab:: APT installer
-
-            Step 1: Set up repository
-
-            .. code-block:: bash
-
-               wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-               echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-               sudo apt update
-
-            Step 2: Install the package
-
-            .. code-block:: bash
-
-               sudo apt install -y intel-basekit=2024.0.1-43
-
-            .. note::
-
-               You can uninstall the package by running the following command:
-
-               .. code-block:: bash
-               
-                  sudo apt autoremove intel-basekit
 
          .. tab:: Offline installer
          
@@ -308,6 +325,38 @@ IPEX-LLM GPU support on Linux has been verified on:
       Intel® oneAPI Base Toolkit 2023.2 installation methods:
 
       .. tabs::
+         .. tab:: APT installer
+
+            Step 1: Set up repository
+
+            .. code-block:: bash
+
+               wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+               echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+               sudo apt update
+
+            Step 2: Install the packages
+
+            .. code-block:: bash
+
+               sudo apt install -y intel-oneapi-common-vars=2023.2.0-49462 \
+                  intel-oneapi-compiler-cpp-eclipse-cfg=2023.2.0-49495 intel-oneapi-compiler-dpcpp-eclipse-cfg=2023.2.0-49495 \
+                  intel-oneapi-diagnostics-utility=2022.4.0-49091 \
+                  intel-oneapi-compiler-dpcpp-cpp=2023.2.0-49495 \
+                  intel-oneapi-mkl=2023.2.0-49495 intel-oneapi-mkl-devel=2023.2.0-49495 \
+                  intel-oneapi-mpi=2021.10.0-49371 intel-oneapi-mpi-devel=2021.10.0-49371 \
+                  intel-oneapi-tbb=2021.10.0-49541 intel-oneapi-tbb-devel=2021.10.0-49541\
+                  intel-oneapi-ccl=2021.10.0-49084 intel-oneapi-ccl-devel=2021.10.0-49084\
+                  intel-oneapi-dnnl-devel=2023.2.0-49516 intel-oneapi-dnnl=2023.2.0-49516
+
+            .. note::
+
+               You can uninstall the package by running the following command:
+
+               .. code-block:: bash
+               
+                  sudo apt autoremove intel-oneapi-common-vars
+
          .. tab:: PIP installer
 
             Step 1: Install oneAPI in a user-defined folder, e.g., ``~/intel/oneapi``
@@ -340,38 +389,6 @@ IPEX-LLM GPU support on Linux has been verified on:
                
                   rm -r ~/intel/oneapi
                   conda env config vars unset LD_LIBRARY_PATH -n llm
-
-         .. tab:: APT installer
-
-            Step 1: Set up repository
-
-            .. code-block:: bash
-
-               wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-               echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-               sudo apt update
-
-            Step 2: Install the packages
-
-            .. code-block:: bash
-
-               sudo apt install -y intel-oneapi-common-vars=2023.2.0-49462 \
-                  intel-oneapi-compiler-cpp-eclipse-cfg=2023.2.0-49495 intel-oneapi-compiler-dpcpp-eclipse-cfg=2023.2.0-49495 \
-                  intel-oneapi-diagnostics-utility=2022.4.0-49091 \
-                  intel-oneapi-compiler-dpcpp-cpp=2023.2.0-49495 \
-                  intel-oneapi-mkl=2023.2.0-49495 intel-oneapi-mkl-devel=2023.2.0-49495 \
-                  intel-oneapi-mpi=2021.10.0-49371 intel-oneapi-mpi-devel=2021.10.0-49371 \
-                  intel-oneapi-tbb=2021.10.0-49541 intel-oneapi-tbb-devel=2021.10.0-49541\
-                  intel-oneapi-ccl=2021.10.0-49084 intel-oneapi-ccl-devel=2021.10.0-49084\
-                  intel-oneapi-dnnl-devel=2023.2.0-49516 intel-oneapi-dnnl=2023.2.0-49516
-
-            .. note::
-
-               You can uninstall the package by running the following command:
-
-               .. code-block:: bash
-               
-                  sudo apt autoremove intel-oneapi-common-vars
 
          .. tab:: Offline installer
          

--- a/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
@@ -111,17 +111,18 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
   sudo apt update
 
   sudo apt install intel-oneapi-common-vars=2024.0.0-49406 \
-    intel-oneapi-compiler-cpp-eclipse-cfg=2024.0.2-49895 \
-    intel-oneapi-compiler-dpcpp-eclipse-cfg=2024.0.2-49895 \
+    intel-oneapi-common-oneapi-vars=2024.0.0-49406 \
     intel-oneapi-diagnostics-utility=2024.0.0-49093 \
     intel-oneapi-compiler-dpcpp-cpp=2024.0.2-49895 \
+    intel-oneapi-dpcpp-ct=2024.0.0-49381 \
     intel-oneapi-mkl=2024.0.0-49656 \
-    intel-oneapi-mkl-devel=2024.0.0-49656 \
     intel-oneapi-mpi=2021.11.0-49493 \
     intel-oneapi-mpi-devel=2021.11.0-49493 \
-    intel-oneapi-tbb=2021.11.0-49513  \
-    intel-oneapi-tbb-devel=2021.11.0-49513 \
-    intel-oneapi-ccl=2021.11.2-5  \
+    intel-oneapi-dal=2024.0.1-25 \
+    intel-oneapi-ippcp=2021.9.1-5 \
+    intel-oneapi-ipp=2021.10.1-13 \
+    intel-oneapi-tlt=2024.0.0-352 \
+    intel-oneapi-ccl=2021.11.2-5 \
     intel-oneapi-ccl-devel=2021.11.2-5 \
     intel-oneapi-dnnl-devel=2024.0.0-49521 \
     intel-oneapi-dnnl=2024.0.0-49521 \

--- a/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
@@ -116,6 +116,7 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
     intel-oneapi-compiler-dpcpp-cpp=2024.0.2-49895 \
     intel-oneapi-dpcpp-ct=2024.0.0-49381 \
     intel-oneapi-mkl=2024.0.0-49656 \
+    intel-oneapi-mkl-devel=2024.0.0-49656 \
     intel-oneapi-mpi=2021.11.0-49493 \
     intel-oneapi-mpi-devel=2021.11.0-49493 \
     intel-oneapi-dal=2024.0.1-25 \

--- a/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
@@ -120,8 +120,11 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
     intel-oneapi-mpi=2021.11.0-49493 \
     intel-oneapi-mpi-devel=2021.11.0-49493 \
     intel-oneapi-dal=2024.0.1-25 \
+    intel-oneapi-dal-devel=2024.0.1-25 \
     intel-oneapi-ippcp=2021.9.1-5 \
+    intel-oneapi-ippcp-devel=2021.9.1-5 \
     intel-oneapi-ipp=2021.10.1-13 \
+    intel-oneapi-ipp-devel=2021.10.1-13 \
     intel-oneapi-tlt=2024.0.0-352 \
     intel-oneapi-ccl=2021.11.2-5 \
     intel-oneapi-ccl-devel=2021.11.2-5 \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This commit sets the apt installer as the default way to install OneAPI on Linux, for two reasons: 
- Firstly, we originally wanted users to install it via pip install because it's simpler. However, pip install only satisfies the runtime needs, not the compilation requirements. Some of our features, such as vLLM, require a compilation environment, which cannot be achieved through pip install. 
- Secondly, most of our internal colleagues require a compilation environment for development. Therefore, we need to maintain environments for both apt and pip installation methods. Providing a compilation environment only for certain machines would lead to resource contention and insufficient machine availability. Moreover, maintaining both methods simultaneously can cause confusion. 

Therefore, for the sake of simplicity for users and colleagues, we have changed the default recommended method to apt installation.

Some users previously reported issues with apt installation method: 
https://github.com/intel-analytics/ipex-llm/issues/10825 
https://github.com/intel-analytics/ipex-llm/issues/10550 
https://github.com/analytics-zoo/nano/issues/1230. 
This commit also addresses the missing packages to resolve the issue of package absence.