### PR TITLE
LLM: update split qkv native sdp.

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/chatglm2.py
+++ b/python/llm/src/ipex_llm/transformers/models/chatglm2.py
@@ -543,7 +543,7 @@ def core_attn_forward_8eb45c(query_layer, key_layer, value_layer, attention_mask
                 for q, k, v in zip(query_split, key_split, value_split):
                     result = F.scaled_dot_product_attention(q, k, v, is_causal=True).to(k.dtype)
                     results.append(result)
-                context_layer = torch.cat(results)
+                context_layer = torch.cat(results, dim=1)
             else:
                 context_layer = F.scaled_dot_product_attention(query_layer.to(key_layer.dtype),
                                                                key_layer,

--- a/python/llm/src/ipex_llm/transformers/models/chatglm2.py
+++ b/python/llm/src/ipex_llm/transformers/models/chatglm2.py
@@ -258,16 +258,14 @@ def chatglm2_quantized_attention_forward_8eb45c(
             query_split = torch.split(query_layer, block_size, dim=1)
             key_split = torch.split(key, block_size, dim=1)
             value_split = torch.split(value, block_size, dim=1)
-            context_layer = torch.empty(batch_size, n_head, seq_len,
-                                        head_dim, dtype=key.dtype).to(query_layer.device)
-            idx = 0
+            results = []
             for q, k, v in zip(query_split, key_split, value_split):
                 if attention_mask is None:
                     result = F.scaled_dot_product_attention(q, k, v, is_causal=True)
                 else:
                     result = F.scaled_dot_product_attention(q, k, v, attention_mask)
-                context_layer[:, idx:idx+q.shape[1], :, :] = result
-                idx = idx + q.shape[1]
+                results.append(result)
+            context_layer = torch.cat(results, dim=1)
         else:
             if attention_mask is None:
                 context_layer = F.scaled_dot_product_attention(query_layer, key,
@@ -541,14 +539,11 @@ def core_attn_forward_8eb45c(query_layer, key_layer, value_layer, attention_mask
                 query_split = torch.split(query_layer.to(key_layer.dtype), block_size, dim=1)
                 key_split = torch.split(key_layer, block_size, dim=1)
                 value_split = torch.split(value_layer, block_size, dim=1)
-                batch_size, n_head, seq_len, head_dim = query_layer.shape
-                context_layer = torch.empty(batch_size, n_head, seq_len,
-                                            head_dim, dtype=key_layer.dtype).to(query_layer.device)
-                idx = 0
+                results = []
                 for q, k, v in zip(query_split, key_split, value_split):
                     result = F.scaled_dot_product_attention(q, k, v, is_causal=True).to(k.dtype)
-                    context_layer[:, idx:idx+q.shape[1], :, :] = result
-                    idx = idx + q.shape[1]
+                    results.append(result)
+                context_layer = torch.cat(results)
             else:
                 context_layer = F.scaled_dot_product_attention(query_layer.to(key_layer.dtype),
                                                                key_layer,


### PR DESCRIPTION
## Description

This PR is update split qkv native sdp function:

- Replace pre-apply memory block for `attn_output` with `attn_output` list and concat function, to get better first token latency performance.

### Simple perf test code and results for different implementation:

```python
import torch
import intel_extension_for_pytorch as ipex
import time

st = time.perf_counter()
seq_len = 256

for j in range(50):
    a = torch.empty(1, 32, seq_len, 128).to("xpu")
    for i in range(4):
        b = torch.randn(1, 8, seq_len, 128).to("xpu")
        a[:, i:i+8, :, :] = b

print("fullfill empty tensor cache sdp:", time.perf_counter()-st, "s", torch.xpu.memory.memory_reserved() / (1024 ** 3), "GB")

del a, b
torch.xpu.empty_cache()
st = time.perf_counter()
for j in range(50):
    c = []
    for i in range(4):
        b = torch.randn(1, 8, seq_len, 128).to("xpu")
        c.append(b)
    a = torch.cat(c, dim=1)
print("concat tensors sdp:", time.perf_counter()-st, "s", torch.xpu.memory.memory_reserved() / (1024 ** 3), "GB")

```

results:

```shell
fullfill empty tensor cache sdp: 0.24240112904226407 s 0.021484375 GB
concat tensors sdp: 0.14562554203439504 s 0.025390625 GB
```

Concat tensors implementation get better latency performance and have minor impact on memory.
