### PR TITLE
Galore finetuning with less memory

### DIFF
--- a/python/llm/example/GPU/LLM-Finetuning/GaLore/galore_finetuning.py
+++ b/python/llm/example/GPU/LLM-Finetuning/GaLore/galore_finetuning.py
@@ -36,9 +36,11 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     model_path = args.repo_id_or_model_path
+    output_dir = args.output_dir
 
     model = AutoModelForCausalLM.from_pretrained(
         model_path,
+        load_in_low_bit = 'sym_int8',
         torch_dtype = torch.bfloat16,
         optimize_model=False,
         use_cache = False,
@@ -68,7 +70,7 @@ if __name__ == '__main__':
     from transformers import TrainingArguments
 
     training_arguments = TrainingArguments(
-        output_dir = f"out",
+        output_dir = output_dir,
         evaluation_strategy = "steps",
         label_names = ["data"],
         per_device_train_batch_size = 16,


### PR DESCRIPTION
## Description

Loading model with low bit can reduce a lot of memory, similar to 8-bit Galore finetuning.

### 1. Why the change?

- Add parameter  `load_in_low_bit = 'sym_int8'`
- Fix the output_dir


### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
