### PR TITLE
Disable fast_init_ in load_low_bit

### DIFF
--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -673,7 +673,7 @@ class _BaseAutoModelClass:
             resolved_archive_file,
             pretrained_model_name_or_path,
             sharded_metadata=sharded_metadata,
-            _fast_init=False, # always false to avoid pre-init behaviors
+            _fast_init=False,  # always false to avoid pre-init behaviors
             low_cpu_mem_usage=bigdl_lcmu_enabled,
             offload_folder=offload_folder,
             offload_state_dict=offload_state_dict,

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -673,7 +673,7 @@ class _BaseAutoModelClass:
             resolved_archive_file,
             pretrained_model_name_or_path,
             sharded_metadata=sharded_metadata,
-            _fast_init=_fast_init,
+            _fast_init=False, # always false to avoid pre-init behaviors
             low_cpu_mem_usage=bigdl_lcmu_enabled,
             offload_folder=offload_folder,
             offload_state_dict=offload_state_dict,


### PR DESCRIPTION
## Description

related issue: https://github.com/intel-analytics/ipex-llm/issues/10826
For all saved low bit weights are already processed and need no initialized, this will not effect our function now.