### PR TITLE
Change order of chatglm2-6b and chatglm3-6b in iGPU perf test for more stable performance

### DIFF
--- a/python/llm/test/benchmark/igpu-perf/1024-128.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128.yaml
@@ -1,6 +1,6 @@
 repo_id:
-  - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'THUDM/chatglm2-6b'
   - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'baichuan-inc/Baichuan2-13B-Chat'
   - 'internlm/internlm-chat-7b-8k'

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16.yaml
@@ -1,6 +1,6 @@
 repo_id:
-  - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'THUDM/chatglm2-6b'
   - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'baichuan-inc/Baichuan2-13B-Chat'
   - 'internlm/internlm-chat-7b-8k'

--- a/python/llm/test/benchmark/igpu-perf/1024-128_loadlowbit.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_loadlowbit.yaml
@@ -1,6 +1,6 @@
 repo_id:
-  - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'THUDM/chatglm2-6b'
   - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'baichuan-inc/Baichuan2-13B-Chat'
   - 'internlm/internlm-chat-7b-8k'

--- a/python/llm/test/benchmark/igpu-perf/2048-256.yaml
+++ b/python/llm/test/benchmark/igpu-perf/2048-256.yaml
@@ -1,6 +1,6 @@
 repo_id:
-  - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'THUDM/chatglm2-6b'
   - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'baichuan-inc/Baichuan2-13B-Chat'
   - 'internlm/internlm-chat-7b-8k'

--- a/python/llm/test/benchmark/igpu-perf/32-32.yaml
+++ b/python/llm/test/benchmark/igpu-perf/32-32.yaml
@@ -1,6 +1,6 @@
 repo_id:
-  - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'THUDM/chatglm2-6b'
   - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'baichuan-inc/Baichuan2-13B-Chat'
   - 'internlm/internlm-chat-7b-8k'


### PR DESCRIPTION
## Description

Change order of chatglm2-6b and chatglm3-6b in iGPU perf test for more stable performance

Related issue: https://github.com/analytics-zoo/nano/issues/913#issuecomment-2097219911