### PR TITLE
Update environment variable setting in AutoTP with arc

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/run-deepspeed-arc.sh
+++ b/python/llm/dev/benchmark/all-in-one/run-deepspeed-arc.sh
@@ -10,7 +10,11 @@ source $basekit_root/ccl/latest/env/vars.sh --force
 
 NUM_GPUS=2 # number of used GPU
 export USE_XETLA=OFF
-export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
+if grep -q "Xeon" /proc/cpuinfo; then
+    export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0
+else
+    export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
+fi
 export TORCH_LLM_ALLREDUCE=0 # Different from PVC
 
 mpirun -np $NUM_GPUS --prepend-rank python run.py

--- a/python/llm/dev/benchmark/all-in-one/run-deepspeed-arc.sh
+++ b/python/llm/dev/benchmark/all-in-one/run-deepspeed-arc.sh
@@ -10,9 +10,7 @@ source $basekit_root/ccl/latest/env/vars.sh --force
 
 NUM_GPUS=2 # number of used GPU
 export USE_XETLA=OFF
-if grep -q "Xeon" /proc/cpuinfo; then
-    export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0
-else
+if grep -q "Core" /proc/cpuinfo; then
     export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
 fi
 export TORCH_LLM_ALLREDUCE=0 # Different from PVC

--- a/python/llm/example/GPU/Deepspeed-AutoTP/run_vicuna_33b_arc_2_card.sh
+++ b/python/llm/example/GPU/Deepspeed-AutoTP/run_vicuna_33b_arc_2_card.sh
@@ -26,7 +26,11 @@ source $basekit_root/ccl/latest/env/vars.sh --force
 
 NUM_GPUS=2 # number of used GPU
 export USE_XETLA=OFF
-export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
+if grep -q "Xeon" /proc/cpuinfo; then
+    export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0
+else
+    export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
+fi
 export TORCH_LLM_ALLREDUCE=0 # Different from PVC
 
 mpirun -np $NUM_GPUS --prepend-rank \

--- a/python/llm/example/GPU/Deepspeed-AutoTP/run_vicuna_33b_arc_2_card.sh
+++ b/python/llm/example/GPU/Deepspeed-AutoTP/run_vicuna_33b_arc_2_card.sh
@@ -26,9 +26,7 @@ source $basekit_root/ccl/latest/env/vars.sh --force
 
 NUM_GPUS=2 # number of used GPU
 export USE_XETLA=OFF
-if grep -q "Xeon" /proc/cpuinfo; then
-    export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0
-else
+if grep -q "Core" /proc/cpuinfo; then
     export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2
 fi
 export TORCH_LLM_ALLREDUCE=0 # Different from PVC


### PR DESCRIPTION
## Description

According to benchmark experiments on multi ARC with different type CPU, `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS` setting have different infulence.


### 4. How to test?
- [x] Local test

