### PR TITLE
[WIP] Support llama2 with transformers==4.38.0

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -963,16 +963,22 @@ def _optimize_post(model, lightweight_bmm=False):
             # transformers version >= 4.36.0
             from ipex_llm.transformers.models.llama import llama_attention_forward_4_38
             from ipex_llm.transformers.models.llama import llama_model_forward_4_36
-            convert_forward(
-                model,
-                transformers.models.llama.modeling_llama.LlamaAttention,
-                llama_attention_forward_4_38)
-            if version.parse(trans_version) <= version.parse("4.38.0"):
+            if version.parse(trans_version) >= version.parse("4.38.0"):
+                from ipex_llm.transformers.models.llama import llama_attention_forward_4_38_original
                 # Todo: support llama_model_forward with transformers version >= 4.38.0
+                convert_forward(
+                    model,
+                    transformers.models.llama.modeling_llama.LlamaAttention,
+                    llama_attention_forward_4_38_original)
+            else:
                 convert_forward(
                     model,
                     transformers.models.llama.modeling_llama.LlamaModel,
                     llama_model_forward_4_36)
+                convert_forward(
+                    model,
+                    transformers.models.llama.modeling_llama.LlamaAttention,
+                    llama_attention_forward_4_38)
         else:
             # transformers version between 4.31.0 - 4.35.2
             convert_forward(

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -967,10 +967,12 @@ def _optimize_post(model, lightweight_bmm=False):
                 model,
                 transformers.models.llama.modeling_llama.LlamaAttention,
                 llama_attention_forward_4_36, )
-            convert_forward(
-                model,
-                transformers.models.llama.modeling_llama.LlamaModel,
-                llama_model_forward_4_36)
+            if version.parse(trans_version) <= version.parse("4.38.0"):
+                # Todo: support llama_model_forward with transformers version >= 4.38.0
+                convert_forward(
+                    model,
+                    transformers.models.llama.modeling_llama.LlamaModel,
+                    llama_model_forward_4_36)
         else:
             # transformers version between 4.31.0 - 4.35.2
             convert_forward(

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -961,12 +961,12 @@ def _optimize_post(model, lightweight_bmm=False):
                         llama_decoder_forward)
         if version.parse(trans_version) >= version.parse("4.36.0"):
             # transformers version >= 4.36.0
-            from ipex_llm.transformers.models.llama import llama_attention_forward_4_36
+            from ipex_llm.transformers.models.llama import llama_attention_forward_4_38
             from ipex_llm.transformers.models.llama import llama_model_forward_4_36
             convert_forward(
                 model,
                 transformers.models.llama.modeling_llama.LlamaAttention,
-                llama_attention_forward_4_36, )
+                llama_attention_forward_4_38)
             if version.parse(trans_version) <= version.parse("4.38.0"):
                 # Todo: support llama_model_forward with transformers version >= 4.38.0
                 convert_forward(

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -919,20 +919,21 @@ def llama_attention_selective_batching_forward_4_31(
     return attn_output.to(original_dtype), attn_weights, updated_past_key_values
 
 
-def llama_attention_forward_4_36(
+def llama_attention_forward_4_38(
     self,
     hidden_states: torch.Tensor,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_value: Optional[Cache] = None,
+    past_key_value: Optional[List[torch.FloatTensor]] = None,
     output_attentions: bool = False,
     use_cache: bool = False,
+    cache_position: Optional[torch.LongTensor] = None,
     **kwargs
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Cache]]:
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[List[torch.FloatTensor]]]:
     if use_quantize_kv_cache(self.q_proj, hidden_states):
-        forward_function = llama_attention_forward_4_36_quantized
+        forward_function = llama_attention_forward_4_38_quantized
     else:
-        forward_function = llama_attention_forward_4_36_original
+        forward_function = llama_attention_forward_4_38_original
     return forward_function(
         self=self,
         hidden_states=hidden_states,
@@ -941,20 +942,22 @@ def llama_attention_forward_4_36(
         past_key_value=past_key_value,
         output_attentions=output_attentions,
         use_cache=use_cache,
+        cache_position=cache_position,
         kwargs=kwargs
     )
 
 
-def llama_attention_forward_4_36_quantized(
+def llama_attention_forward_4_38_quantized(
     self,
     hidden_states: torch.Tensor,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_value: Optional[Cache] = None,
+    past_key_value: Optional[List[torch.FloatTensor]] = None,
     output_attentions: bool = False,
     use_cache: bool = False,
+    cache_position: Optional[torch.LongTensor] = None,
     **kwargs
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Cache]]:
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[List[torch.FloatTensor]]]:
     if "padding_mask" in kwargs:
         warnings.warn(
             "Passing `padding_mask` is deprecated and will be removed in v4.37. "
@@ -1026,9 +1029,15 @@ def llama_attention_forward_4_36_quantized(
                                                                          "llama",
                                                                          rope_theta=rope_theta)
         else:
-            cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-            query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
-                                                            cos, sin, position_ids, "llama")
+            if cache_position is not None:
+                # for transformers 4.38.0
+                cos, sin = self.rotary_emb(value_states, position_ids)
+                query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
+                                                                cos, sin, position_ids, "llama2")
+            else:
+                cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+                query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
+                                                                cos, sin, position_ids, "llama")
     kv_seq_len = key_states.shape[-2]
 
     if len(past_key_value.key_cache) <= self.layer_idx:
@@ -1037,7 +1046,8 @@ def llama_attention_forward_4_36_quantized(
         if should_split_qkv_tensor(query_states, bsz, self.num_heads,
                                    q_len, kv_seq_len, output_attentions):
             attn_output, _ = native_sdp_split_qkv_tensor(query_states, repeated_key_states,
-                                                         repeated_value_states, attention_mask,
+                                                         repeated_value_states, 
+                                                         attention_mask, cache_position,
                                                          bsz, q_len, kv_seq_len, self.head_dim,
                                                          self.num_heads)
         else:
@@ -1053,13 +1063,17 @@ def llama_attention_forward_4_36_quantized(
                 )
 
             if attention_mask is not None:
-                if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
-                    invalidInputError(
-                        False,
-                        f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)},"
-                        f" but is {attention_mask.size()}"
-                    )
-                attn_weights = attn_weights + attention_mask
+                if cache_position is not None:
+                    # for transformers 4.38.0
+                    causal_mask = attention_mask[:, :, cache_position, : kv_seq_len]
+                    attn_weights = attn_weights + causal_mask
+                else:
+                    attn_mask_size = (bsz, 1, q_len, kv_seq_len)
+                    if attention_mask.size() != attn_mask_size:
+                        invalidInputError(False,
+                                          f"Attention mask should be of size {attn_mask_size}, "
+                                          f"but is {attention_mask.size()}")
+                    attn_weights = attn_weights + attention_mask
 
             if kv_seq_len >= 2048 or bsz >= 64:
                 # for memory considerations, do not upcast attention to fp32
@@ -1097,13 +1111,17 @@ def llama_attention_forward_4_36_quantized(
                 )
 
             if attention_mask is not None:
-                if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
-                    invalidInputError(
-                        False,
-                        f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)},"
-                        f" but is {attention_mask.size()}"
-                    )
-                attn_weights = attn_weights + attention_mask
+                if cache_position is not None:
+                    # for transformers 4.38.0
+                    causal_mask = attention_mask[:, :, cache_position, : kv_seq_len]
+                    attn_weights = attn_weights + causal_mask
+                else:
+                    attn_mask_size = (bsz, 1, q_len, kv_seq_len)
+                    if attention_mask.size() != attn_mask_size:
+                        invalidInputError(False,
+                                          f"Attention mask should be of size {attn_mask_size}, "
+                                          f"but is {attention_mask.size()}")
+                    attn_weights = attn_weights + attention_mask
 
             if kv_seq_len >= 2048 or bsz >= 64:
                 # for memory considerations, do not upcast attention to fp32
@@ -1146,7 +1164,7 @@ def llama_attention_forward_4_36_quantized(
     return attn_output, attn_weights, past_key_value
 
 
-def llama_attention_forward_4_36_original(
+def llama_attention_forward_4_38_original(
     self,
     hidden_states: torch.Tensor,
     attention_mask: Optional[torch.Tensor] = None,
@@ -1431,14 +1449,15 @@ def native_sdp(query, key, value, attention_mask, cache_position,
 
         if attention_mask is not None:
             if cache_position is not None:
+                # for transformers 4.38.0
                 causal_mask = attention_mask[:, :, cache_position, : kv_seq_len]
                 attn_weights = attn_weights + causal_mask
             else:
                 attn_mask_size = (bsz, 1, q_len, kv_seq_len)
                 if attention_mask.size() != attn_mask_size:
                     invalidInputError(False,
-                                    f"Attention mask should be of size {attn_mask_size}, "
-                                    f"but is {attention_mask.size()}")
+                                      f"Attention mask should be of size {attn_mask_size}, "
+                                      f"but is {attention_mask.size()}")
                 attn_weights = attn_weights + attention_mask
 
         if kv_seq_len >= 2048 or bsz >= 64:
@@ -1471,14 +1490,15 @@ def native_sdp_split_qkv_tensor(query, key, value, attention_mask, cache_positio
 
         if attention_mask is not None:
             if cache_position is not None:
+                # for transformers 4.38.0
                 causal_mask = attention_mask[:, :, cache_position, : kv_seq_len]
                 attn_weights = attn_weights + causal_mask
             else:
                 attn_mask_size = (bsz, 1, q_len, kv_seq_len)
                 if attention_mask.size() != attn_mask_size:
                     invalidInputError(False,
-                                    f"Attention mask should be of size {attn_mask_size}, "
-                                    f"but is {attention_mask.size()}")
+                                      f"Attention mask should be of size {attn_mask_size}, "
+                                      f"but is {attention_mask.size()}")
                 attn_weights = attn_weights + attention_mask
         attn_weights_split = nn.functional.softmax(attn_weights_split, dim=-1)
         attn_outputs.append(torch.matmul(attn_weights_split, v))

--- a/python/llm/src/ipex_llm/transformers/models/llama.py
+++ b/python/llm/src/ipex_llm/transformers/models/llama.py
@@ -1051,7 +1051,7 @@ def llama_attention_forward_4_38_quantized(
         if should_split_qkv_tensor(query_states, bsz, self.num_heads,
                                    q_len, kv_seq_len, output_attentions):
             attn_output, _ = native_sdp_split_qkv_tensor(query_states, repeated_key_states,
-                                                         repeated_value_states, 
+                                                         repeated_value_states,
                                                          attention_mask, cache_position,
                                                          bsz, q_len, kv_seq_len, self.head_dim,
                                                          self.num_heads)

--- a/python/llm/src/ipex_llm/transformers/models/utils.py
+++ b/python/llm/src/ipex_llm/transformers/models/utils.py
@@ -178,6 +178,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
         q_embed = (q * cos) + (rotate_half(q) * sin)
         k_embed = (k * cos) + (rotate_half(k) * sin)
         return q_embed, k_embed
+    elif model_family == "llama2":
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        q_embed = (q * cos) + (rotate_half(q) * sin)
+        k_embed = (k * cos) + (rotate_half(k) * sin)
+        return q_embed, k_embed
     elif model_family == "gptj":
         q_embed = (q * cos) + (rotate_every_two(q) * sin)
         k_embed = (k * cos) + (rotate_every_two(k) * sin)


### PR DESCRIPTION
### 1. Why the change?

llama2 model failed with transformers==4.38.0.

### 2. User API changes

n/a

### 3. Summary of the change 
- [x] support llama2 with 4.38.0
- [x] merge 4.38.0 implementation with 4.36.0
- [x] support sdp kernel
- [ ] support llama_model_forward (will be merged in another pr)

### 4. How to test?
- [x] 4.31.0 test
- [x] 4.36.0 test
- [x] 4.38.0 test

