### PR TITLE
disable mlp fusion of fp6 on mtl

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/utils.py
+++ b/python/llm/src/ipex_llm/transformers/models/utils.py
@@ -358,6 +358,10 @@ def mlp_fusion_check(x, qtype, training):
         return False
     if training or x.requires_grad:
         return False
+    if qtype == FP6:
+        device = get_xpu_device_type(x)
+        if device == "mtl":
+            return False
     return True
 
 


### PR DESCRIPTION
## Description

disable mlp fusion of fp6 on mtl as it causes performance regression.

### 1. Why the change?
https://github.com/intel-analytics/llm.cpp/pull/407
