### PR TITLE
update homepage url for ipex-llm

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -319,7 +319,7 @@ def setup_package():
         author='BigDL Authors',
         author_email='bigdl-user-group@googlegroups.com',
         license='Apache License, Version 2.0',
-        url='https://github.com/intel-analytics/BigDL',
+        url='https://github.com/intel-analytics/ipex-llm',
         packages=get_llm_packages(),
         package_dir={"": "src"},
         package_data={

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -39,7 +39,7 @@ import copy
 from setuptools import setup
 
 long_description = '''
-    IPEX LLM
+    IPEX-LLM is a PyTorch library for running LLM on Intel CPU and GPU (e.g., local PC with iGPU, discrete GPU such as Arc, Flex and Max) with very low latency
 '''
 
 exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -339,7 +339,7 @@ def setup_package():
         classifiers=[
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: Implementation :: CPython'],
         scripts={
             'Linux': ['src/ipex_llm/cli/llm-cli', 'src/ipex_llm/cli/llm-chat', 'scripts/ipex-llm-init'],


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?



As user mentioned in issue: https://github.com/intel-analytics/ipex-llm/issues/11079#issuecomment-2122955481, when executing `pip show ipex-llm`, the Home Page Url still shows "Home-page: https://github.com/intel-analytics/BigDL", this submission is to update the url.