### PR TITLE
Fix Arc UT

### DIFF
--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -276,7 +276,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade "setuptools<70.0.0"
           python -m pip install --upgrade wheel
           python -m pip install --upgrade notebook
 


### PR DESCRIPTION
![image](https://github.com/intel-analytics/ipex-llm/assets/54161268/08b8df8c-e58d-4f22-9738-5c2d75fdae77)

`setuptools<70.0.0` will resolve this import problem

TODO: We may add related troubleshooting (if default setuptools installed by conda may also be >=70.0.0)