### PR TITLE
Add `setuptools` limitation for `ipex-llm[xpu]`

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -293,6 +293,7 @@ def setup_package():
     xpu_21_requires = copy.deepcopy(all_requires)
     for exclude_require in cpu_torch_version:
         xpu_21_requires.remove(exclude_require)
+    xpu_21_requires += ["setuptools<70.0.0"]
     xpu_21_requires += ["torch==2.1.0a0",
                         "torchvision==0.16.0a0",
                         "intel_extension_for_pytorch==2.1.10+xpu",


### PR DESCRIPTION
## Description

Add `setuptools` limitation for `ipex-llm[xpu]`

### 1. Why the change?

https://github.com/intel-analytics/ipex-llm/pull/11096#issue-2309579140