### PR TITLE
upgrade torch/torchaudio/torchvision for ipex in finetune xpu image

### DIFF
--- a/docker/llm/finetune/xpu/Dockerfile
+++ b/docker/llm/finetune/xpu/Dockerfile
@@ -46,6 +46,9 @@ RUN curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     pip install transformers==4.36.0 && \
     pip install peft==0.10.0 datasets accelerate==0.23.0 && \
     pip install bitsandbytes scipy fire && \
+    pip install tokenizers==0.15.2 && \
+    # upgrade torch, torchaudio and torchvision for intel-extension-for-pytorch
+    pip install torch==2.1.0a0 torchvision==0.16.0a0 torchaudio==2.1.0a0 intel-extension-for-pytorch==2.1.10+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ && \
     # Prepare accelerate config
     mkdir -p /root/.cache/huggingface/accelerate && \
     mv /LLM-Finetuning/axolotl/default_config.yaml /root/.cache/huggingface/accelerate/


### PR DESCRIPTION
…orch

## Description

The versions of torch, torchaudio and torchvision do not match ipex=2.1.10, which results in the error `ImportError: /usr/local/lib/python3.11/dist-packages/intel_extension_for_pytorch/lib/libintel-ext-pt-gpu.so: undefined symbol: _ZNK5torch8autograd4Node4nameB5cxx11Ev
` when loading ipex.
upgrade torch, torchaudio and torchvision for matching ipex==2.1.10
upgarde tokenizer to 0.15.2

### 1. Why the change?

install torch==2.1.0a0 torchvision==0.16.0a0 torchaudio==2.1.0a0 tokenizer==0.15.2


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
