### PR TITLE
Fix type mismatch in eval for Baichuan2 QLora example

### DIFF
--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
@@ -175,6 +175,23 @@ bash qlora_finetune_qwen15_7b_arc_1_card.sh
 
 ##### Finetuning Baichuan2-7B examples on single Arc A770
 
+Modify `modeling_baichuan.py` in model dir. Add following 2 lines into Line 234. This changes fix [Baichuan2 type mismatch issue](https://github.com/baichuan-inc/Baichuan2/issues/291).
+
+```python
+if(attention_mask.dtype != query_states.dtype):
+    attention_mask = attention_mask.to(query_states.dtype)
+```
+
+After modification, line 234-236 should look like below.
+
+```python
+with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_math=True, enable_mem_efficient=True):
+    if(attention_mask.dtype != query_states.dtype):
+        attention_mask = attention_mask.to(query_states.dtype)
+    attn_output = F.scaled_dot_product_attention(query_states, key_states, value_states, attn_mask = attention_mask)
+```
+Launch finetune.
+
 ```bash
 bash qlora_finetune_baichuan2_7b_arc_1_card.sh
 ```

--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
@@ -175,7 +175,7 @@ bash qlora_finetune_qwen15_7b_arc_1_card.sh
 
 ##### Finetuning Baichuan2-7B examples on single Arc A770
 
-Modify `modeling_baichuan.py` in model dir. Add following 2 lines into Line 234. This change fixes [Baichuan2 type mismatch issue](https://github.com/baichuan-inc/Baichuan2/issues/291).
+Please download [Baichuan2-7B-Chat](https://huggingface.co/baichuan-inc/Baichuan2-7B-Chat). Modify `modeling_baichuan.py` in model dir. Add following 2 lines into Line 234. This change fixes [Baichuan2 type mismatch issue](https://github.com/baichuan-inc/Baichuan2/issues/291).
 
 ```python
 if(attention_mask.dtype != query_states.dtype):
@@ -190,7 +190,7 @@ with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_math=True, enable_
         attention_mask = attention_mask.to(query_states.dtype)
     attn_output = F.scaled_dot_product_attention(query_states, key_states, value_states, attn_mask = attention_mask)
 ```
-Launch finetune.
+Modify `--base_model` in `qlora_finetune_baichuan2_7b_arc_1_card.sh`. Then, launch finetune.
 
 ```bash
 bash qlora_finetune_baichuan2_7b_arc_1_card.sh

--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
@@ -175,7 +175,7 @@ bash qlora_finetune_qwen15_7b_arc_1_card.sh
 
 ##### Finetuning Baichuan2-7B examples on single Arc A770
 
-Modify `modeling_baichuan.py` in model dir. Add following 2 lines into Line 234. This changes fix [Baichuan2 type mismatch issue](https://github.com/baichuan-inc/Baichuan2/issues/291).
+Modify `modeling_baichuan.py` in model dir. Add following 2 lines into Line 234. This change fixes [Baichuan2 type mismatch issue](https://github.com/baichuan-inc/Baichuan2/issues/291).
 
 ```python
 if(attention_mask.dtype != query_states.dtype):

--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/qlora_finetune_baichuan2_7b_arc_1_card.sh
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/qlora_finetune_baichuan2_7b_arc_1_card.sh
@@ -16,6 +16,6 @@
 
 # You could also specify `--base_model` to the local path of the huggingface model checkpoint folder and `--data_path` to the local path of the dataset JSON file
 python ./alpaca_qlora_finetuning.py \
-    --base_model "baichuan-inc/Baichuan2-7B-Chat" \
+    --base_model "path/to/Baichuan2-7B-Chat" \
     --data_path "yahma/alpaca-cleaned" \
     --output_dir "./ipex-llm-qlora-alpaca"


### PR DESCRIPTION
## Description

During evaluation, Baichuan2 will raise type mismatch when training with bfloat16. Fix this issue by modifying modeling_baichuan.py

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [x] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
