### PR TITLE
Add half precision for fastchat models

### DIFF
--- a/python/llm/src/ipex_llm/transformers/loader.py
+++ b/python/llm/src/ipex_llm/transformers/loader.py
@@ -91,6 +91,8 @@ def load_model(
 
     if device == "xpu":
         import intel_extension_for_pytorch as ipex
+        print("Convert model to half precision...")
+        model = model.half()
         model = model.to('xpu')
 
     return model, tokenizer


### PR DESCRIPTION
## Description

Add half precision for fastchat models.


Test done:

- [x] gradio web server
- [x] openai api server
- [x] tgi api server


![image](https://github.com/intel-analytics/ipex-llm/assets/110874468/7ae71e95-2d2a-4aad-91ab-6c9d3ca16c73)
