### PR TITLE
Fix mixtral-8x7b with transformers=4.37.0

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/mixtral.py
+++ b/python/llm/src/ipex_llm/transformers/models/mixtral.py
@@ -414,6 +414,9 @@ def mixtral_model_forward(
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
 ) -> Union[Tuple, MoeModelOutputWithPast]:
+    # to be compatible with transformers>=4.37.0
+    self._use_flash_attention_2 = self.config._attn_implementation == "flash_attention_2"
+
     output_attentions = output_attentions if output_attentions is not None \
         else self.config.output_attentions
     output_router_logits = (


### PR DESCRIPTION
## Description

When run mixtral-8x7b with transformers=4.37.0, exist following error:
![image](https://github.com/intel-analytics/ipex-llm/assets/108676127/8e05daf6-f292-468b-bf7c-9cb1808a9838)

Because `mixtral_model_forward`(https://github.com/intel-analytics/ipex-llm/blob/main/python/llm/src/ipex_llm/transformers/models/mixtral.py#L404) is based on transformers 4.36.0, but `self._use_flash_attention_2` is removed in initiation of transformers 4.37.0.

Fix it. 

### 4. How to test?
- [x] Local test
