### PR TITLE
[Docker] Fix image using two cards error

### DIFF
--- a/docker/llm/inference/xpu/docker/Dockerfile
+++ b/docker/llm/inference/xpu/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     pip install transformers_stream_generator einops tiktoken && \
     # Install opencl-related repos
     apt-get update && \
-    apt-get install -y intel-opencl-icd intel-level-zero-gpu=1.3.26241.33-647~22.04 level-zero level-zero-dev --allow-downgrades && \
+    apt-get install -y intel-opencl-icd intel-level-zero-gpu level-zero && \
     # Install related libary of chat.py
     pip install --upgrade colorama && \
     # Download all-in-one benchmark and examples

--- a/docs/readthedocs/source/doc/LLM/Quickstart/fastchat_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/fastchat_quickstart.md
@@ -119,16 +119,17 @@ python3 -m ipex_llm.serving.fastchat.vllm_worker --model-path REPO_ID_OR_YOUR_MO
 
 #### Launch multiple workers
 
-Sometimes we may want to start multiple workers for the best performance.  For running in CPU, you may want to seperate multiple workers in different socket.  Assuming each socket have 48 physicall cores, then you may want to start two workers using the following example:
+Sometimes we may want to start multiple workers for the best performance.  For running in CPU, you may want to seperate multiple workers in different sockets.  Assuming each socket have 48 physicall cores, then you may want to start two workers using the following example:
 
 ```bash
+export OMP_NUM_THREADS=48
 numactl -C 0-47 -m 0 python3 -m ipex_llm.serving.fastchat.ipex_llm_worker --model-path REPO_ID_OR_YOUR_MODEL_PATH --low-bit "sym_int4" --trust-remote-code --device "cpu" &
 
 # All the workers other than the first worker need to specify a different worker port and corresponding worker-address
-numactl -C 48-95 -m 0 python3 -m ipex_llm.serving.fastchat.ipex_llm_worker --model-path REPO_ID_OR_YOUR_MODEL_PATH --low-bit "sym_int4" --trust-remote-code --device "cpu" --port 21003 --worker-address "http://localhost:21003" &
+numactl -C 48-95 -m 1 python3 -m ipex_llm.serving.fastchat.ipex_llm_worker --model-path REPO_ID_OR_YOUR_MODEL_PATH --low-bit "sym_int4" --trust-remote-code --device "cpu" --port 21003 --worker-address "http://localhost:21003" &
 ```
 
-For GPU, we may want to start two workers using different GPUs.  To achieve this, you should use `ZE_AFFINITY_MASK` environment variable to select different GPU for different workers.  Below shows an example:
+For GPU, we may want to start two workers using different GPUs.  To achieve this, you should use `ZE_AFFINITY_MASK` environment variable to select different GPUs for different workers.  Below shows an example:
 
 ```bash
 ZE_AFFINITY_MASK=1 python3 -m ipex_llm.serving.fastchat.ipex_llm_worker --model-path REPO_ID_OR_YOUR_MODEL_PATH --low-bit "sym_int4" --trust-remote-code --device "xpu" &

--- a/python/llm/src/ipex_llm/serving/fastchat/vllm_worker.py
+++ b/python/llm/src/ipex_llm/serving/fastchat/vllm_worker.py
@@ -41,6 +41,9 @@ from fastchat.serve.model_worker import (
     worker_id,
 )
 from fastchat.utils import get_context_length, is_partial_stop
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ipex_llm.vllm.cpu.engine import IPEXLLMAsyncLLMEngine as AsyncLLMEngine
 
 
 app = FastAPI()
@@ -56,7 +59,7 @@ class VLLMWorker(BaseModelWorker):
         model_names: List[str],
         limit_worker_concurrency: int,
         no_register: bool,
-        llm_engine: AsyncLLMEngine,
+        llm_engine: 'AsyncLLMEngine',
         conv_template: str,
     ):
         super().__init__(


### PR DESCRIPTION
## Description

In machine with two A770 cards, when using card 2, the following error will occur:
```bash
2024-05-27 18:08:59 | ERROR | stderr |   File "/usr/local/lib/python3.11/dist-packages/ipex_llm/transformers/models/llama.py", line 1493, in native_sdp
2024-05-27 18:08:59 | ERROR | stderr |     attn_weights = torch.matmul(query.to(key.dtype),
2024-05-27 18:08:59 | ERROR | stderr |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-27 18:08:59 | ERROR | stderr | RuntimeError: could not create a primitive
```

This error can be fixed by re-installing the compute runtime:  `intel-opencl-icd` `intel-level-zero-gpu` `level-zero`.

Also, this PR adds doc about running multiple workers in FastChat + fix vllm_worker.

## Tested:

- [x] FastChat
- [x] chat.py
- [x] vllm