### PR TITLE
Refactor pipeline parallel device config

### DIFF
--- a/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
@@ -62,27 +62,9 @@ if __name__ == '__main__':
                                                  load_in_4bit=True,
                                                  optimize_model=True,
                                                  trust_remote_code=True,
-                                                 use_cache=True)
-
-    model_layers = ['model.embed_tokens']
-    for i in range(model.config.num_hidden_layers):
-        model_layers.append(f'model.layers.{i}')
-    model_layers = model_layers + ['model.norm', 'lm_head']
-
-    device_map = {}
-    split_len = len(model_layers) // args.gpu_num
-    for i in range(args.gpu_num):
-        device_map.update({key: f'xpu:{i}' for key in model_layers[split_len * i: split_len * (i + 1)]})
-        if i == args.gpu_num - 1:
-            device_map.update({key: f'xpu:{i}' for key in model_layers[split_len * (i + 1): ]})
-
-    from accelerate import dispatch_model
-    model = dispatch_model(
-        model,
-        device_map=device_map,
-        offload_dir=None,
-        skip_keys=["past_key_value", "past_key_values"],
-    )
+                                                 use_cache=True,
+                                                 pipeline_parallel=True,
+                                                 parallel_gpu_num=args.gpu_num)
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)

--- a/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
@@ -63,8 +63,7 @@ if __name__ == '__main__':
                                                  optimize_model=True,
                                                  trust_remote_code=True,
                                                  use_cache=True,
-                                                 pipeline_parallel=True,
-                                                 parallel_gpu_num=args.gpu_num)
+                                                 pipeline_parallel_stage=args.gpu_num)
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)

--- a/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
                                                  optimize_model=True,
                                                  trust_remote_code=True,
                                                  use_cache=True,
-                                                 pipeline_parallel_stage=args.gpu_num)
+                                                 pipeline_parallel_stages=args.gpu_num)
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -157,6 +157,10 @@ class _BaseAutoModelClass:
         :param mixed_precision: boolean value, Whether to use mixed precision quantization.
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
+        :param pipeline_parallel: boolean value, Whether to use pipeline parallel inference.
+                                  Default to be ``False``.
+        :param parallel_gpu_num: int value, the number of GPUs allocated for pipeline parallel
+                                 inference. Default to be ``None``.
         :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -105,10 +105,10 @@ def pipeline_parallel(model, pipeline_parallel_stages):
     split_len = len(model_layers) // pipeline_parallel_stages
     for i in range(pipeline_parallel_stages):
         device_map.update({key: f'xpu:{i}' for key in
-                            model_layers[split_len * i: split_len * (i + 1)]})
+                           model_layers[split_len * i: split_len * (i + 1)]})
         if i == pipeline_parallel_stages - 1:
             device_map.update({key: f'xpu:{i}' for key in
-                                model_layers[split_len * (i + 1):]})
+                               model_layers[split_len * (i + 1):]})
 
     from accelerate import dispatch_model
     model = dispatch_model(
@@ -180,7 +180,7 @@ class _BaseAutoModelClass:
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
         :param pipeline_parallel_stages: int value, the number of GPUs allocated for
-            pipeline parallel. Default to be ``None``. Please set pipeline_parallel_stages > 1 
+            pipeline parallel. Default to be ``None``. Please set pipeline_parallel_stages > 1
             to run pipeline parallel inference on multiple GPUs.
         :return: a model instance
         """

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -180,7 +180,7 @@ class _BaseAutoModelClass:
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
         :param pipeline_parallel_stage: int value, the number of GPUs allocated for
-            pipeline parallel. Default to be ``1``. Pipeline parallel will be enabled if 
+            pipeline parallel. Default to be ``None``. Pipeline parallel will be enabled if
             pipeline_parallel_stage > 1.
         :return: a model instance
         """
@@ -215,7 +215,7 @@ class _BaseAutoModelClass:
         optimize_model = kwargs.pop("optimize_model", True)
         user_quantization_config = kwargs.pop("quantization_config", None)
         speculative = kwargs.pop("speculative", False)
-        pipeline_parallel_stages = kwargs.pop("pipeline_parallel_stages", 1)
+        pipeline_parallel_stages = kwargs.pop("pipeline_parallel_stages", None)
         torch_dtype = kwargs.pop("torch_dtype", None)
         embedding_qtype = kwargs.pop("embedding_qtype", None)
 
@@ -372,12 +372,16 @@ class _BaseAutoModelClass:
             kwargs["embedding_qtype"] = embedding_qtype
             model = cls.load_convert(q_k, optimize_model, *args, **kwargs)
 
-            if pipeline_parallel_stages > 1:
-                model = pipeline_parallel(model, pipeline_parallel_stages)
+            if pipeline_parallel_stages:
                 if speculative:
                     invalidInputError(False,
                                       f"Please do not set speculative=True"
                                       f" when using pipeline_parallel_stages")
+                if pipeline_parallel_stages == 1:
+                    warnings.warn(
+                        "Please set pipeline_parallel_stages > 1 to enable pipeline parallel",
+                        FutureWarning)
+                model = pipeline_parallel(model, pipeline_parallel_stages)
 
             if speculative:
                 from .speculative import speculative_generate, clear_benchmarks,\

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -180,7 +180,7 @@ class _BaseAutoModelClass:
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
         :param pipeline_parallel_stages: int value, the number of GPUs allocated for
-            pipeline parallel. Default to be ``None``. Please set pipeline_parallel_stages > 1
+            pipeline parallel. Default to be ``1``. Please set pipeline_parallel_stages > 1
             to run pipeline parallel inference on multiple GPUs.
         :return: a model instance
         """
@@ -215,7 +215,7 @@ class _BaseAutoModelClass:
         optimize_model = kwargs.pop("optimize_model", True)
         user_quantization_config = kwargs.pop("quantization_config", None)
         speculative = kwargs.pop("speculative", False)
-        pipeline_parallel_stages = kwargs.pop("pipeline_parallel_stages", None)
+        pipeline_parallel_stages = kwargs.pop("pipeline_parallel_stages", 1)
         torch_dtype = kwargs.pop("torch_dtype", None)
         embedding_qtype = kwargs.pop("embedding_qtype", None)
 
@@ -372,16 +372,11 @@ class _BaseAutoModelClass:
             kwargs["embedding_qtype"] = embedding_qtype
             model = cls.load_convert(q_k, optimize_model, *args, **kwargs)
 
-            if pipeline_parallel_stages:
+            if pipeline_parallel_stages > 1:
                 if speculative:
                     invalidInputError(False,
                                       f"Please do not set speculative=True"
                                       f" when using pipeline_parallel_stages")
-                if pipeline_parallel_stages == 1:
-                    warnings.warn(
-                        "Please set pipeline_parallel_stages > 1 to "
-                        "run pipeline parallel inference on multiple GPUs",
-                        FutureWarning)
                 model = pipeline_parallel(model, pipeline_parallel_stages)
 
             if speculative:

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -179,9 +179,9 @@ class _BaseAutoModelClass:
         :param mixed_precision: boolean value, Whether to use mixed precision quantization.
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
-        :param pipeline_parallel_stage: int value, the number of GPUs allocated for
-            pipeline parallel. Default to be ``None``. Pipeline parallel will be enabled if
-            pipeline_parallel_stage > 1.
+        :param pipeline_parallel_stages: int value, the number of GPUs allocated for
+            pipeline parallel. Default to be ``None``. Please set pipeline_parallel_stages > 1 
+            to run pipeline parallel inference on multiple GPUs.
         :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
@@ -379,7 +379,8 @@ class _BaseAutoModelClass:
                                       f" when using pipeline_parallel_stages")
                 if pipeline_parallel_stages == 1:
                     warnings.warn(
-                        "Please set pipeline_parallel_stages > 1 to enable pipeline parallel",
+                        "Please set pipeline_parallel_stages > 1 to "
+                        "run pipeline parallel inference on multiple GPUs",
                         FutureWarning)
                 model = pipeline_parallel(model, pipeline_parallel_stages)
 

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -361,7 +361,7 @@ class _BaseAutoModelClass:
                                        model_layers[split_len * i: split_len * (i + 1)]})
                     if i == parallel_gpu_num - 1:
                         device_map.update({key: f'xpu:{i}' for key in
-                                           model_layers[split_len * (i + 1): ]})
+                                           model_layers[split_len * (i + 1):]})
 
                 from accelerate import dispatch_model
                 model = dispatch_model(

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -95,6 +95,28 @@ def save_low_bit(self, *args, **kwargs):
         self.to(origin_device)
 
 
+def pipeline_parallel(model, pipeline_parallel_stages):
+    model_layers = ['model.embed_tokens']
+    for i in range(model.config.num_hidden_layers):
+        model_layers.append(f'model.layers.{i}')
+    model_layers = model_layers + ['model.norm', 'lm_head']
+
+    device_map = {}
+    split_len = len(model_layers) // pipeline_parallel_stages
+    for i in range(pipeline_parallel_stages):
+        device_map.update({key: f'xpu:{i}' for key in
+                            model_layers[split_len * i: split_len * (i + 1)]})
+        if i == pipeline_parallel_stages - 1:
+            device_map.update({key: f'xpu:{i}' for key in
+                                model_layers[split_len * (i + 1):]})
+
+    from accelerate import dispatch_model
+    model = dispatch_model(
+        model, device_map=device_map, skip_keys=["past_key_value", "past_key_values"],
+    )
+    return model
+
+
 def _load_pre():
     from transformers import GPTJModel
     from ipex_llm.transformers.models.gptj import gptj_model_new_init
@@ -157,10 +179,9 @@ class _BaseAutoModelClass:
         :param mixed_precision: boolean value, Whether to use mixed precision quantization.
             Default to be False. If set to True, we will use sym_int8 for lm_head when
             load_in_low_bit is sym_int4 or asym_int4.
-        :param pipeline_parallel: boolean value, Whether to use pipeline parallel inference.
-                                  Default to be ``False``.
-        :param parallel_gpu_num: int value, the number of GPUs allocated for pipeline parallel
-                                 inference. Default to be ``None``.
+        :param pipeline_parallel_stage: int value, the number of GPUs allocated for
+            pipeline parallel. Default to be ``1``. Pipeline parallel will be enabled if 
+            pipeline_parallel_stage > 1.
         :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
@@ -194,8 +215,7 @@ class _BaseAutoModelClass:
         optimize_model = kwargs.pop("optimize_model", True)
         user_quantization_config = kwargs.pop("quantization_config", None)
         speculative = kwargs.pop("speculative", False)
-        pipeline_parallel = kwargs.pop("pipeline_parallel", False)
-        parallel_gpu_num = kwargs.pop("parallel_gpu_num", None)
+        pipeline_parallel_stages = kwargs.pop("pipeline_parallel_stages", 1)
         torch_dtype = kwargs.pop("torch_dtype", None)
         embedding_qtype = kwargs.pop("embedding_qtype", None)
 
@@ -352,25 +372,12 @@ class _BaseAutoModelClass:
             kwargs["embedding_qtype"] = embedding_qtype
             model = cls.load_convert(q_k, optimize_model, *args, **kwargs)
 
-            if pipeline_parallel:
-                model_layers = ['model.embed_tokens']
-                for i in range(model.config.num_hidden_layers):
-                    model_layers.append(f'model.layers.{i}')
-                model_layers = model_layers + ['model.norm', 'lm_head']
-
-                device_map = {}
-                split_len = len(model_layers) // parallel_gpu_num
-                for i in range(parallel_gpu_num):
-                    device_map.update({key: f'xpu:{i}' for key in
-                                       model_layers[split_len * i: split_len * (i + 1)]})
-                    if i == parallel_gpu_num - 1:
-                        device_map.update({key: f'xpu:{i}' for key in
-                                           model_layers[split_len * (i + 1):]})
-
-                from accelerate import dispatch_model
-                model = dispatch_model(
-                    model, device_map=device_map, skip_keys=["past_key_value", "past_key_values"],
-                )
+            if pipeline_parallel_stages > 1:
+                model = pipeline_parallel(model, pipeline_parallel_stages)
+                if speculative:
+                    invalidInputError(False,
+                                      f"Please do not set speculative=True"
+                                      f" when using pipeline_parallel_stages")
 
             if speculative:
                 from .speculative import speculative_generate, clear_benchmarks,\


### PR DESCRIPTION
## Description

This PR is mainly created to optimize the usage for pipeline parallel inference.

### 1. Why the change?

There are too many configurations (such as device_map and model_layers) that need to be specified by the user in the example.

### 2. User API changes
```python
    model = AutoModelForCausalLM.from_pretrained(model_path,
                                                 load_in_4bit=True,
                                                 optimize_model=True,
                                                 trust_remote_code=True,
                                                 use_cache=True,
                                                 pipeline_parallel_stages=2)
```

### 3. Summary of the change 


### 4. How to test?
- [ ] Unit test
- [x] Application test
