### PR TITLE
fix issue 1407

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -799,7 +799,7 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
     if optimize_model:
         model = _optimize_post(model, lightweight_bmm)
 
-    if hasattr(model, "config") and \
+    if hasattr(model, "config") and hasattr(model.config, "model_type") and \
             model.config.model_type == "qwen" and hasattr(model.config, "visual"):
         # for Qwen-VL-Chat
         # Due to issue https://github.com/intel/intel-extension-for-pytorch/issues/454,


### PR DESCRIPTION
## Description
Bark and Mamba models failed for not having model_type in the configuration,  add ``` hasattr(model.config, "model_type") ``` while checking model.config.model_type  in convert.py
 Fix issue 1407 https://github.com/analytics-zoo/nano/issues/1407
### 2. How to test?
- [ ] N/A
- [ ] Unit test
- [x] example test
- [ ] Document test
- [ ] ...
