### PR TITLE
Fix IPEX auto importer

### DIFF
--- a/python/llm/example/CPU/Applications/streaming-llm/streaming_llm/utils.py
+++ b/python/llm/example/CPU/Applications/streaming-llm/streaming_llm/utils.py
@@ -51,7 +51,6 @@ import json
 # code change to import from IPEX-LLM API instead of using transformers API
 from ipex_llm.transformers import AutoModelForCausalLM
 from transformers import LlamaTokenizer
-import intel_extension_for_pytorch as ipex
 
 
 def load(model_name_or_path):

--- a/python/llm/example/CPU/Deepspeed-AutoTP/deepspeed_autotp.py
+++ b/python/llm/example/CPU/Deepspeed-AutoTP/deepspeed_autotp.py
@@ -47,7 +47,6 @@ from transformers import AutoModelForCausalLM, LlamaTokenizer, AutoTokenizer
 import deepspeed
 from ipex_llm import optimize_model
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/codeshell/server.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/codeshell/server.py
@@ -274,9 +274,6 @@ if __name__ == "__main__":
     multi_turn = args.multi_turn
     max_context = args.max_context
 
-    if device == 'xpu':
-        import intel_extension_for_pytorch as ipex
-
     model = model.to(device)
 
     model.generation_config = GenerationConfig.from_pretrained(

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm2/generate.py
@@ -20,7 +20,6 @@ import argparse
 
 from transformers import AutoTokenizer
 from ipex_llm import optimize_model
-import intel_extension_for_pytorch as ipex
 
 # you could tune the prompt based on your own model,
 # here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/phixtral/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/phixtral/generate.py
@@ -20,7 +20,6 @@ import argparse
 import numpy as np
 
 from transformers import AutoTokenizer, GenerationConfig
-import intel_extension_for_pytorch as ipex
 
 
 # you could tune the prompt based on your own model,

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen1.5/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen1.5/generate.py
@@ -20,7 +20,6 @@ import argparse
 
 from transformers import AutoTokenizer
 from ipex_llm import optimize_model
-import intel_extension_for_pytorch as ipex
 import numpy as np
 
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/solar/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/solar/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yuan2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yuan2/generate.py
@@ -16,7 +16,6 @@
 
 import torch, transformers
 import sys, os, time
-import intel_extension_for_pytorch as ipex
 import argparse
 from transformers import LlamaTokenizer
 from ipex_llm.transformers import AutoModelForCausalLM

--- a/python/llm/example/GPU/Pipeline-Parallel-FastAPI/pipeline_models.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-FastAPI/pipeline_models.py
@@ -1,7 +1,6 @@
 from torch import nn
 import torch
 import torch.distributed as dist
-import intel_extension_for_pytorch as ipex
 
 from typing import List, Optional, Tuple, Union, Iterator
 import time

--- a/python/llm/example/GPU/Pipeline-Parallel-FastAPI/pipeline_serving.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-FastAPI/pipeline_serving.py
@@ -2,7 +2,6 @@ from pipeline_models import ModelRunner
 import torch.nn.parallel
 import torch.distributed as dist
 import os
-import intel_extension_for_pytorch as ipex
 
 import oneccl_bindings_for_pytorch
 

--- a/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-Inference/generate.py
@@ -16,7 +16,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/internlm2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/internlm2/generate.py
@@ -20,7 +20,6 @@ import argparse
 
 from transformers import AutoTokenizer
 from ipex_llm import optimize_model
-import intel_extension_for_pytorch as ipex
 
 # you could tune the prompt based on your own model,
 # here the prompt tuning refers to https://huggingface.co/internlm/internlm-chat-7b/blob/main/modeling_internlm.py#L1053

--- a/python/llm/example/GPU/PyTorch-Models/Model/mamba/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/mamba/generate.py
@@ -17,7 +17,6 @@
 import argparse
 import time
 import torch
-import intel_extension_for_pytorch as ipex
 from ipex_llm import optimize_model
 from transformers import AutoTokenizer
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/phixtral/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/phixtral/generate.py
@@ -20,7 +20,6 @@ import argparse
 import numpy as np
 
 from transformers import AutoTokenizer, GenerationConfig
-import intel_extension_for_pytorch as ipex
 from ipex_llm import optimize_model
 
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/qwen1.5/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/qwen1.5/generate.py
@@ -20,7 +20,6 @@ import argparse
 
 from transformers import AutoTokenizer
 from ipex_llm import optimize_model
-import intel_extension_for_pytorch as ipex
 import numpy as np
 
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/solar/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/solar/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/yuan2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/yuan2/generate.py
@@ -16,7 +16,6 @@
 
 import torch, transformers
 import sys, os, time
-import intel_extension_for_pytorch as ipex
 import argparse
 from transformers import LlamaTokenizer, AutoModelForCausalLM
 from ipex_llm import optimize_model

--- a/python/llm/example/GPU/Speculative-Decoding/EAGLE/evaluation/gen_ea_answer_llama2chat.py
+++ b/python/llm/example/GPU/Speculative-Decoding/EAGLE/evaluation/gen_ea_answer_llama2chat.py
@@ -47,7 +47,6 @@ from eagle.model.ea_model import EaModel
 from eagle.model.utils import *
 from eagle.model.kv_cache import initialize_past_key_values
 from eagle.model.choices import *
-import intel_extension_for_pytorch as ipex
 from ipex_llm import optimize_model
 
 def ea_forward(input_ids, model, tokenizer, tree_choices, logits_processor=None, max_steps=512):

--- a/python/llm/src/ipex_llm/__init__.py
+++ b/python/llm/src/ipex_llm/__init__.py
@@ -25,16 +25,13 @@ import os
 from .llm_patching import llm_patch, llm_unpatch
 import sys
 import types
-import builtins
 
 # Default is false, set to true to auto importing Intel Extension for PyTorch.
 BIGDL_IMPORT_IPEX = os.getenv("BIGDL_IMPORT_IPEX", 'True').lower() in ('true', '1', 't')
 if BIGDL_IMPORT_IPEX:
     # Import Intel Extension for PyTorch as ipex if XPU version is installed
     from .utils.ipex_importer import ipex_importer
-    ipex = ipex_importer.import_ipex()
-    if ipex is not None:
-        builtins.ipex = ipex
+    ipex_importer.import_ipex()
 
 # Default is true, set to true to auto patching bigdl-llm to ipex_llm.
 BIGDL_COMPATIBLE_MODE = os.getenv("BIGDL_COMPATIBLE_MODE", 'True').lower() in ('true', '1', 't')

--- a/python/llm/src/ipex_llm/__init__.py
+++ b/python/llm/src/ipex_llm/__init__.py
@@ -25,13 +25,16 @@ import os
 from .llm_patching import llm_patch, llm_unpatch
 import sys
 import types
+import builtins
 
 # Default is false, set to true to auto importing Intel Extension for PyTorch.
 BIGDL_IMPORT_IPEX = os.getenv("BIGDL_IMPORT_IPEX", 'True').lower() in ('true', '1', 't')
 if BIGDL_IMPORT_IPEX:
     # Import Intel Extension for PyTorch as ipex if XPU version is installed
     from .utils.ipex_importer import ipex_importer
-    ipex_importer.import_ipex()
+    ipex = ipex_importer.import_ipex()
+    if ipex is not None:
+        builtins.ipex = ipex
 
 # Default is true, set to true to auto patching bigdl-llm to ipex_llm.
 BIGDL_COMPATIBLE_MODE = os.getenv("BIGDL_COMPATIBLE_MODE", 'True').lower() in ('true', '1', 't')

--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -52,7 +52,7 @@ class IPEXImporter:
 
     def import_ipex(self):
         """
-        Try to import Intel Extension for PyTorch as ipex
+        Try to import Intel Extension for PyTorch as ipex for XPU
 
         Raises ImportError if failed
         """
@@ -60,14 +60,24 @@ class IPEXImporter:
             # Check if user import ipex manually
             if 'ipex' in sys.modules or 'intel_extension_for_pytorch' in sys.modules:
                 logging.error("IPEX-LLM will automatically import Intel Extension for PyTorch.")
-                raise ImportError("Please avoid import Intel Extension for PyTorch manually!")
-            # import ipex
-            import intel_extension_for_pytorch as ipex
-            if ipex is not None:
-                # Expose ipex to Python builtins
-                builtins.ipex = ipex
+                raise ImportError("Please import ipex-llm before importing intel_extension_for_pytorch!")
+            self.directly_import_ipex()
             self.ipex_version = ipex.__version__
             logging.info("intel_extension_for_pytorch auto imported")
+
+    def directly_import_ipex(self):
+        """
+        Try to import Intel Extension for PyTorch as ipex
+
+        Raises ImportError if failed
+        """
+        # import ipex
+        import intel_extension_for_pytorch as ipex
+        if ipex is not None:
+            # Expose ipex to Python builtins
+            builtins.ipex = ipex
+        else:
+            raise ImportError("Can not import intel_extension_for_pytorch.")
 
     def get_ipex_version(self):
         """
@@ -78,15 +88,8 @@ class IPEXImporter:
         if self.ipex_version is not None:
             return self.ipex_version
         # try to import Intel Extension for PyTorch and get version
-        try:
-            import intel_extension_for_pytorch as ipex
-            if ipex is not None:
-                # Expose ipex to Python builtins
-                builtins.ipex = ipex
-            self.ipex_version = ipex.__version__
-        except ImportError:
-            logging.warning("Can not import intel_extension_for_pytorch.")
-            self.ipex_version = None
+        self.directly_import_ipex()
+        self.ipex_version = ipex.__version__
         return self.ipex_version
 
 

--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -61,9 +61,9 @@ class IPEXImporter:
         if self.is_xpu_version_installed():
             # Check if user import ipex manually
             if 'ipex' in sys.modules or 'intel_extension_for_pytorch' in sys.modules:
-                logging.error("IPEX-LLM will automatically import Intel Extension for PyTorch.")
+                logging.error("ipex_llm will automatically import intel_extension_for_pytorch.")
                 log4Error.invalidInputError(False,
-                                            "Please import ipex-llm before importing \
+                                            "Please import ipex_llm before importing \
                                                 intel_extension_for_pytorch!")
             self.directly_import_ipex()
             self.ipex_version = ipex.__version__

--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -59,6 +59,9 @@ class IPEXImporter:
             import intel_extension_for_pytorch as ipex
             self.ipex_version = ipex.__version__
             logging.info("intel_extension_for_pytorch auto imported")
+            return ipex
+        else:
+            return None
 
     def get_ipex_version(self):
         """

--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -18,6 +18,7 @@ from importlib.metadata import distribution, PackageNotFoundError
 import logging
 import builtins
 import sys
+from ipex_llm.utils.common import log4Error
 
 class IPEXImporter:
     """
@@ -60,7 +61,8 @@ class IPEXImporter:
             # Check if user import ipex manually
             if 'ipex' in sys.modules or 'intel_extension_for_pytorch' in sys.modules:
                 logging.error("IPEX-LLM will automatically import Intel Extension for PyTorch.")
-                raise ImportError("Please import ipex-llm before importing intel_extension_for_pytorch!")
+                log4Error.invalidInputError(False, 
+                                            "Please import ipex-llm before importing intel_extension_for_pytorch!")
             self.directly_import_ipex()
             self.ipex_version = ipex.__version__
             logging.info("intel_extension_for_pytorch auto imported")
@@ -77,7 +79,8 @@ class IPEXImporter:
             # Expose ipex to Python builtins
             builtins.ipex = ipex
         else:
-            raise ImportError("Can not import intel_extension_for_pytorch.")
+            log4Error.invalidInputError(False,
+                                        "Can not import intel_extension_for_pytorch.")
 
     def get_ipex_version(self):
         """

--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -20,6 +20,7 @@ import builtins
 import sys
 from ipex_llm.utils.common import log4Error
 
+
 class IPEXImporter:
     """
     Auto import Intel Extension for PyTorch as ipex,
@@ -55,14 +56,15 @@ class IPEXImporter:
         """
         Try to import Intel Extension for PyTorch as ipex for XPU
 
-        Raises ImportError if failed
+        Raises ImportError and invalidInputError if failed
         """
         if self.is_xpu_version_installed():
             # Check if user import ipex manually
             if 'ipex' in sys.modules or 'intel_extension_for_pytorch' in sys.modules:
                 logging.error("IPEX-LLM will automatically import Intel Extension for PyTorch.")
-                log4Error.invalidInputError(False, 
-                                            "Please import ipex-llm before importing intel_extension_for_pytorch!")
+                log4Error.invalidInputError(False,
+                                            "Please import ipex-llm before importing \
+                                                intel_extension_for_pytorch!")
             self.directly_import_ipex()
             self.ipex_version = ipex.__version__
             logging.info("intel_extension_for_pytorch auto imported")
@@ -71,7 +73,7 @@ class IPEXImporter:
         """
         Try to import Intel Extension for PyTorch as ipex
 
-        Raises ImportError if failed
+        Raises ImportError and invalidInputError if failed
         """
         # import ipex
         import intel_extension_for_pytorch as ipex

--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -17,6 +17,7 @@
 from importlib.metadata import distribution, PackageNotFoundError
 import logging
 import builtins
+import sys
 
 class IPEXImporter:
     """
@@ -56,15 +57,10 @@ class IPEXImporter:
         Raises ImportError if failed
         """
         if self.is_xpu_version_installed():
-            ipex_imported = False
-            try:
-                distribution('intel_extension_for_pytorch')
-                ipex_importer = True
-            except PackageNotFoundError:
-                pass
-            if ipex_imported:
-                logging.warning("IPEX-LLM will automatically import Intel Extension for PyTorch.",
-                                "Please avoid import Intel Extension for PyTorch manually!")
+            # Check if user import ipex manually
+            if 'ipex' in sys.modules or 'intel_extension_for_pytorch' in sys.modules:
+                logging.error("IPEX-LLM will automatically import Intel Extension for PyTorch.")
+                raise ImportError("Please avoid import Intel Extension for PyTorch manually!")
             # import ipex
             import intel_extension_for_pytorch as ipex
             if ipex is not None:


### PR DESCRIPTION
## Description

* Fix ipex auto importer with builtins.
* Raise importError if the user imports ipex manually before importing ipex_llm. Do nothing if they import ipex after importing ipex_llm.
* Remove import ipex in examples. 

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
