### PR TITLE
Remove software-properties-common Module to Eliminate GPL/LGPL Dependency

### DIFF
--- a/docker/llm/finetune/lora/cpu/docker/Dockerfile
+++ b/docker/llm/finetune/lora/cpu/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 
 RUN mkdir /ipex_llm/data && mkdir /ipex_llm/model && \
 # Install python 3.11.1
-    apt-get update && apt-get install -y curl wget gpg gpg-agent software-properties-common git gcc g++ make libunwind8-dev zlib1g-dev libssl-dev libffi-dev && \
+    apt-get update && apt-get install -y curl wget gpg gpg-agent git gcc g++ make libunwind8-dev zlib1g-dev libssl-dev libffi-dev && \
     mkdir -p /opt/python && \
     cd /opt/python && \
     wget https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tar.xz && \

--- a/docker/llm/finetune/qlora/cpu/docker/Dockerfile
+++ b/docker/llm/finetune/qlora/cpu/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 RUN mkdir -p /ipex_llm/data && mkdir -p /ipex_llm/model && \
     # Install python 3.11.1
     apt-get update && \
-    apt-get install -y curl wget gpg gpg-agent software-properties-common git gcc g++ make libunwind8-dev libbz2-dev zlib1g-dev libssl-dev libffi-dev && \
+    apt-get install -y curl wget gpg gpg-agent git gcc g++ make libunwind8-dev libbz2-dev zlib1g-dev libssl-dev libffi-dev && \
     mkdir -p /opt/python && \
     cd /opt/python && \
     wget https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tar.xz && \

--- a/docker/llm/finetune/qlora/cpu/docker/Dockerfile.k8s
+++ b/docker/llm/finetune/qlora/cpu/docker/Dockerfile.k8s
@@ -22,7 +22,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 RUN mkdir -p /ipex_llm/data && mkdir -p /ipex_llm/model && \
     # Install python 3.11.1
     apt-get update && apt-get install -y openssh-server openssh-client libcap2-bin gnupg2 ca-certificates \
-    curl wget gpg gpg-agent software-properties-common git \
+    curl wget gpg gpg-agent git \
     gcc g++ make libunwind8-dev zlib1g-dev libssl-dev libffi-dev && \
     mkdir -p /opt/python && \
     cd /opt/python && \

--- a/docker/llm/finetune/xpu/Dockerfile
+++ b/docker/llm/finetune/xpu/Dockerfile
@@ -14,13 +14,12 @@ RUN curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     # update dependencies
     apt-get update && \
     # install basic dependencies
-    apt-get install -y curl wget git gnupg gpg-agent software-properties-common libunwind8-dev vim less && \
+    apt-get install -y curl wget git gnupg gpg-agent libunwind8-dev vim less && \
     # install Intel GPU driver
     apt-get install -y intel-opencl-icd intel-level-zero-gpu level-zero level-zero-dev --allow-downgrades && \
     # install python 3.11
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get install -y python3.11 python3-pip python3.11-dev python3-wheel python3.11-distutils && \
     # avoid axolotl lib conflict
     apt-get remove -y python3-blinker && apt autoremove -y && \

--- a/docker/llm/inference-cpp/Dockerfile
+++ b/docker/llm/inference-cpp/Dockerfile
@@ -21,8 +21,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     # Install PYTHON 3.11 and IPEX-LLM[xpu]
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt install software-properties-common libunwind8-dev vim less -y && \
-    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt install libunwind8-dev vim less -y && \
     apt-get install -y python3.11 git curl wget && \
     rm /usr/bin/python3 && \
     ln -s /usr/bin/python3.11 /usr/bin/python3 && \

--- a/docker/llm/inference/cpu/docker/Dockerfile
+++ b/docker/llm/inference/cpu/docker/Dockerfile
@@ -12,12 +12,10 @@ COPY ./start-notebook.sh /llm/start-notebook.sh
 # Update the software sources
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
 # Install essential packages
-    apt install software-properties-common libunwind8-dev vim less -y && \
+    apt install libunwind8-dev vim less -y && \
 # Install git, curl, and wget
     apt-get install -y git curl wget && \
 # Install Python 3.11
-    # Add Python 3.11 PPA repository
-    add-apt-repository ppa:deadsnakes/ppa -y && \
     # Install Python 3.11
     apt-get install -y python3.11 && \
     # Remove the original /usr/bin/python3 symbolic link

--- a/docker/llm/inference/xpu/docker/Dockerfile
+++ b/docker/llm/inference/xpu/docker/Dockerfile
@@ -26,8 +26,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     # Install PYTHON 3.11 and IPEX-LLM[xpu]
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt install software-properties-common libunwind8-dev vim less -y && \
-    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt install libunwind8-dev vim less -y && \
     apt-get install -y python3.11 git curl wget && \
     rm /usr/bin/python3 && \
     ln -s /usr/bin/python3.11 /usr/bin/python3 && \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission aims to remove the `software-properties-common` module, which introduced the GPL/LGPL license, to meet the requirements of OSPDT. 

`software-properties-common` is a package used for managing software repositories in Ubuntu and related distributions. It provides utilities for adding, removing, and managing apt repositories. The `add-apt-repository` command, which is included in this package, is used to add new apt repositories to your system.  Since the default apt sources already include Python 3.11 related packages, we no longer need it.