### PR TITLE
Fix fp6_k phi3 ppl core dump

### DIFF
--- a/python/llm/dev/benchmark/perplexity/run_wikitext.py
+++ b/python/llm/dev/benchmark/perplexity/run_wikitext.py
@@ -44,6 +44,7 @@ else:  # ipex-llm
                                                  use_cache=args.use_cache, trust_remote_code=True)
     model = model.half()
 model = model.to(args.device)
+model = model.eval()
 
 with open(args.data_path, "rb") as f:
     data = f.read()


### PR DESCRIPTION
## Description

Fix fp6_k phi3 ppl core dump.

### 1. Why the change?

ppl + phi3 + fp6_k will cause core dump since the mlp layers is in the training mode.

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
