### PR TITLE
[Fix] always cleanup conda env after linux-build-avx512

### DIFF
--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -210,6 +210,7 @@ jobs:
           path: |
             avx_release
       - name: Clean up test environment
+        if: ${{ always() }}
         shell: bash
         run: |
           make clean


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission is to fix https://github.com/intel-analytics/ipex-llm/actions/runs/9367630068/job/25816285425