### PR TITLE
support stablm2 12b

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/stablelm.py
+++ b/python/llm/src/ipex_llm/transformers/models/stablelm.py
@@ -131,7 +131,7 @@ def stablelm_attention_forward(
     query_states, key_states, value_states = qkv.split([self.num_heads,
                                                         self.num_key_value_heads,
                                                         self.num_key_value_heads], dim=1)
-    # For stablelm-2-12b's qk per norm
+    # For stablelm-2-12b's qk per-head norm
     if getattr(self, "qk_layernorm", False):
         query_states = self.q_layernorm(query_states)
         key_states = self.k_layernorm(key_states)

--- a/python/llm/src/ipex_llm/transformers/models/stablelm.py
+++ b/python/llm/src/ipex_llm/transformers/models/stablelm.py
@@ -131,6 +131,10 @@ def stablelm_attention_forward(
     query_states, key_states, value_states = qkv.split([self.num_heads,
                                                         self.num_key_value_heads,
                                                         self.num_key_value_heads], dim=1)
+    # For stablelm-2-12b's qk per norm
+    if getattr(self, "qk_layernorm", False):
+        query_states = self.q_layernorm(query_states)
+        key_states = self.k_layernorm(key_states)
 
     kv_seq_len = key_states.shape[-2]
     if past_key_value is not None:


### PR DESCRIPTION
## Description

Add qk layernorm in stablelm2 to support stablelm2-12b. #11246 

Its performance is not good because its head_dim is 160, which is not supported by sdp kernel for now, and its qk norm is too slow