### PR TITLE
Fix gguf_q4k

### DIFF
--- a/python/llm/src/ipex_llm/transformers/embedding.py
+++ b/python/llm/src/ipex_llm/transformers/embedding.py
@@ -97,6 +97,7 @@ class LowBitEmbedding(torch.nn.Embedding):
                                 requires_grad=False,
                                 quantized=False, _shape=None, qtype=qtype)
         self.embedding_dim = embedding_dim
+        self.num_embeddings = num_embeddings
         self.torch_dtype = torch_dtype
 
     def forward(self, x: Tensor):
@@ -110,5 +111,6 @@ class LowBitEmbedding(torch.nn.Embedding):
                               "Please `pip install bigdl_core_xe` first.")
 
         result = xe_linear.dequantize_rows(x.contiguous(), self.weight.data,
-                                           self.weight.qtype, self.embedding_dim)
+                                           self.weight.qtype, self.embedding_dim,
+                                           self.num_embeddings)
         return result.to(self.torch_dtype)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/1434

### 2. User API changes

No change.

### 3. Summary of the change 

- change parameter of `xe_linear.dequantize_rows`
- update `fp16` benchmark api from `model.half()` to `torch_dtype=torch.float16` (only update "transformer_int4_fp16_gpu_win" and "transformer_int4_fp16_gpu" now) as quantized embedding must accept `torch_dtype=torch.float16`

### 4. How to test?
- [x] Unit test

