### PR TITLE
Add intelanalytics/ipex-llm:sources image for OSPDT

### DIFF
--- a/docker/llm/sources/Dockerfile
+++ b/docker/llm/sources/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
+    git \
+    gnupg \
+    numactl \
+    wget && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/llm/sources/Dockerfile
+++ b/docker/llm/sources/Dockerfile
@@ -1,8 +1,17 @@
 FROM ubuntu:22.04
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
+# Add deb-src entries to the sources.list
+RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse" >> /etc/apt/sources.list
+
+# Update package lists and install dpkg-dev
+RUN apt-get update && apt-get install -y dpkg-dev
+
+# Create a temporary directory, adjust permissions, and download source code for the specified packages
+RUN mkdir -p /usr/local/src/git-source && \
+    chown _apt:root /usr/local/src/git-source && \
+    cd /usr/local/src/git-source && \
+    apt-get source \
     git \
     gnupg \
     numactl \
-    wget && \
-    rm -rf /var/lib/apt/lists/*
+    wget

--- a/docker/llm/sources/README.md
+++ b/docker/llm/sources/README.md
@@ -1,0 +1,12 @@
+This is used for OSPDT review.
+
+A separate Docker container layer tagged as: <YOUR_DOCKER_IMAGE>:<xPL_VERSION>-sources tag for sources of 3d party packages with MPL 1.x, MPL 2.x, GPL 1.x, GPL 2.x and GPL 3.x variants.
+
+### Build Image
+```bash
+docker build \
+  --build-arg http_proxy=.. \
+  --build-arg https_proxy=.. \
+  --build-arg no_proxy=.. \
+  --rm --no-cache -t intelanalytics/ipex-llm:sources .
+```


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission adds intelanalytics/ipex-llm:sources docker image for OSPDT, a separate Docker container layer tagged as: <YOUR_DOCKER_IMAGE>:<xPL_VERSION>-sources tag for sources of 3d party packages with MPL 1.x, MPL 2.x, GPL 1.x, GPL 2.x and GPL 3.x variants.