### PR TITLE
Remove accelerate 0.23.0 install command in README and docker

### DIFF
--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -381,7 +381,7 @@ jobs:
         shell: bash
         run: |
           python -m pip uninstall datasets -y
-          python -m pip install transformers==4.36.0 datasets peft==0.10.0 accelerate==0.23.0
+          python -m pip install transformers==4.36.0 datasets peft==0.10.0
           python -m pip install bitsandbytes scipy
           # Specific oneapi position on arc ut test machines
           if [[ "$RUNNER_OS" == "Linux" ]]; then

--- a/docker/llm/finetune/qlora/cpu/docker/Dockerfile
+++ b/docker/llm/finetune/qlora/cpu/docker/Dockerfile
@@ -50,7 +50,6 @@ RUN mkdir -p /ipex_llm/data && mkdir -p /ipex_llm/model && \
     # install huggingface dependencies
     pip install datasets transformers==4.36.0 && \
     pip install fire peft==0.10.0 && \
-    pip install accelerate==0.23.0 && \
     pip install bitsandbytes && \
     # get qlora example code
     cd /ipex_llm && \

--- a/docker/llm/finetune/qlora/cpu/docker/Dockerfile.k8s
+++ b/docker/llm/finetune/qlora/cpu/docker/Dockerfile.k8s
@@ -63,7 +63,6 @@ RUN mkdir -p /ipex_llm/data && mkdir -p /ipex_llm/model && \
     # install huggingface dependencies
     pip install datasets transformers==4.36.0 && \
     pip install fire peft==0.10.0 && \
-    pip install accelerate==0.23.0 && \
     # install basic dependencies
     apt-get update && apt-get install -y curl wget gpg gpg-agent && \
     # Install Intel oneAPI keys.

--- a/docker/llm/finetune/xpu/Dockerfile
+++ b/docker/llm/finetune/xpu/Dockerfile
@@ -41,7 +41,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     rm -rf IPEX-LLM && \
     # install transformers & peft dependencies
     pip install transformers==4.36.0 && \
-    pip install peft==0.10.0 datasets accelerate==0.23.0 && \
+    pip install peft==0.10.0 datasets && \
     pip install bitsandbytes scipy fire && \
     # Prepare accelerate config
     mkdir -p /root/.cache/huggingface/accelerate && \

--- a/docs/readthedocs/source/doc/LLM/Quickstart/axolotl_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/axolotl_quickstart.md
@@ -216,7 +216,6 @@ pip install -e .
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 # install transformers etc
-pip install accelerate==0.23.0
 # to avoid https://github.com/OpenAccess-AI-Collective/axolotl/issues/1544
 pip install datasets==2.15.0
 pip install transformers==4.37.0

--- a/python/llm/example/CPU/QLoRA-FineTuning/README.md
+++ b/python/llm/example/CPU/QLoRA-FineTuning/README.md
@@ -22,7 +22,6 @@ pip install --pre --upgrade ipex-llm[all] --extra-index-url https://download.pyt
 pip install transformers==4.36.0
 pip install peft==0.10.0
 pip install datasets
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/CPU/QLoRA-FineTuning/alpaca-qlora/README.md
+++ b/python/llm/example/CPU/QLoRA-FineTuning/alpaca-qlora/README.md
@@ -10,7 +10,6 @@ conda activate llm
 pip install --pre --upgrade ipex-llm[all]
 pip install datasets transformers==4.36.0
 pip install fire peft==0.10.0
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/DPO/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/DPO/README.md
@@ -19,7 +19,6 @@ conda activate llm
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 pip install transformers==4.36.0 datasets
 pip install trl peft==0.10.0
-pip install accelerate==0.23.0
 pip install bitsandbytes
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/HF-PEFT/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/HF-PEFT/README.md
@@ -17,7 +17,6 @@ pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-exte
 pip install transformers==4.36.0 datasets
 pip install fire peft==0.10.0
 pip install oneccl_bind_pt==2.1.100 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ # necessary to run distributed finetuning
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/LISA/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/LISA/README.md
@@ -13,7 +13,6 @@ conda create -n llm python=3.11
 conda activate llm
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-pip install accelerate==0.23.0
 pip install bitsandbytes==0.43.0
 pip install datasets==2.18.0
 pip install --upgrade transformers==4.36.0

--- a/python/llm/example/GPU/LLM-Finetuning/LoRA/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/LoRA/README.md
@@ -15,7 +15,6 @@ pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-exte
 pip install transformers==4.36.0 datasets
 pip install fire peft==0.10.0
 pip install oneccl_bind_pt==2.1.100 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ # necessary to run distributed finetuning
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/QA-LoRA/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QA-LoRA/README.md
@@ -15,7 +15,6 @@ pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-exte
 pip install transformers==4.36.0 datasets
 pip install fire peft==0.10.0
 pip install oneccl_bind_pt==2.1.100 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ # necessary to run distributed finetuning
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/alpaca-qlora/README.md
@@ -18,7 +18,6 @@ pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-exte
 pip install transformers==4.36.0 datasets
 pip install fire peft==0.10.0
 pip install oneccl_bind_pt==2.1.100 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ # necessary to run distributed finetuning
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 # configures OneAPI environment variables
 source /opt/intel/oneapi/setvars.sh # necessary to run before installing deepspeed

--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/simple-example/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/simple-example/README.md
@@ -19,7 +19,6 @@ conda activate llm
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 pip install transformers==4.36.0 datasets
 pip install peft==0.10.0
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/QLoRA/trl-example/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/QLoRA/trl-example/README.md
@@ -19,7 +19,6 @@ conda activate llm
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 pip install transformers==4.36.0 datasets
 pip install peft==0.10.0
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy trl
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/ReLora/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/ReLora/README.md
@@ -15,7 +15,6 @@ pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-exte
 pip install transformers==4.36.0 datasets
 pip install fire peft==0.10.0
 pip install oneccl_bind_pt==2.1.100 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ # necessary to run distributed finetuning
-pip install accelerate==0.23.0
 pip install bitsandbytes scipy
 ```
 

--- a/python/llm/example/GPU/LLM-Finetuning/axolotl/README.md
+++ b/python/llm/example/GPU/LLM-Finetuning/axolotl/README.md
@@ -132,7 +132,6 @@ pip install -e .
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 # install transformers etc
-pip install accelerate==0.23.0
 # to avoid https://github.com/OpenAccess-AI-Collective/axolotl/issues/1544
 pip install datasets==2.15.0
 pip install transformers==4.37.0


### PR DESCRIPTION
## Description

* ipex-llm's accelerate has been upgraded to 0.23.0. Remove accelerate 0.23.0 install command in README and docker

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
