### PR TITLE
Change mixed_precision type to q6k

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -383,7 +383,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                     if mixed_precision and is_lm_head(name, model_config, out_features):
                         if cur_qtype in [ggml_tensor_qtype["sym_int4"],
                                          ggml_tensor_qtype["asym_int4"]]:
-                            cur_qtype = ggml_tensor_qtype["sym_int8"]
+                            cur_qtype = ggml_tensor_qtype["q6_k"]
 
                     new_linear = LowBitLinear(
                         in_features,


### PR DESCRIPTION
## Description

Change mixed_precision type to q6k

### 1. Why the change?

For better ppl and MTL performance.


### 4. How to test?
- [ ] Local test

