### PR TITLE
FIX: Qwen1.5-GPTQ-Int4 inference error

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/README.md
@@ -18,7 +18,7 @@ conda activate llm
 pip install --pre --upgrade ipex-llm[all] --extra-index-url https://download.pytorch.org/whl/cpu
 pip install transformers==4.34.0
 BUILD_CUDA_EXT=0 pip install git+https://github.com/PanQiWei/AutoGPTQ.git@1de9ab6
-pip install optimum==0.14.0
+pip install optimum==1.14.0
 ```
 
 On Windows:
@@ -30,7 +30,7 @@ pip install --pre --upgrade ipex-llm[all]
 pip install transformers==4.34.0
 set BUILD_CUDA_EXT=0
 pip install git+https://github.com/PanQiWei/AutoGPTQ.git@1de9ab6
-pip install optimum==0.14.0
+pip install optimum==1.14.0
 ```
 
 ### 2. Run

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/generate.py
@@ -19,7 +19,7 @@ import time
 import argparse
 
 from ipex_llm.transformers import AutoModelForCausalLM
-from transformers import LlamaTokenizer, GPTQConfig
+from transformers import LlamaTokenizer, AutoTokenizer
 
 # you could tune the prompt based on your own model,
 # here the prompt tuning refers to https://huggingface.co/georgesung/llama2_7b_chat_uncensored#prompt-style
@@ -50,7 +50,10 @@ if __name__ == '__main__':
                                                  trust_remote_code=True,)
 
     # Load tokenizer
-    tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    if "qwen" in model_path.lower():
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    else:
+        tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
     
     # Generate predicted tokens
     with torch.inference_mode():

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/generate.py
@@ -18,7 +18,7 @@ import torch
 import time
 import argparse
 from ipex_llm.transformers import AutoModelForCausalLM
-from transformers import AutoTokenizer, GPTQConfig
+from transformers import AutoTokenizer, AutoTokenizer
 
 # you could tune the prompt based on your own model,
 # here the prompt tuning refers to https://huggingface.co/georgesung/llama2_7b_chat_uncensored#prompt-style
@@ -48,9 +48,11 @@ if __name__ == '__main__':
                                                  torch_dtype=torch.float,
                                                  trust_remote_code=True,).to("xpu")
     
-    print(model)
     # Load tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    if "qwen" in model_path.lower():
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    else:
+        tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
     
     # Generate predicted tokens
     with torch.inference_mode():

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -733,17 +733,17 @@ def _optimize_pre(model):
         model.apply(split_mlp)
     # for qwen2
     if model.config.model_type == "qwen2":
-        from ipex_llm.transformers.models.qwen2 import merge_qkv
-        # Skip merge_qkv if quant_method is 'gptq'
+        # Skip merge_qkv and padding_mlp if quant_method is 'gptq'
         should_apply_merge_qkv = (
             not hasattr(model.config, "quantization_config") or
             not hasattr(model.config.quantization_config, "quant_method") or
             model.config.quantization_config.quant_method != "gptq"
         )
         if should_apply_merge_qkv:
+            from ipex_llm.transformers.models.qwen2 import merge_qkv
             model.apply(merge_qkv)
-        from ipex_llm.transformers.models.qwen2 import padding_mlp
-        model.apply(padding_mlp)
+            from ipex_llm.transformers.models.qwen2 import padding_mlp
+            model.apply(padding_mlp)
     if model.config.model_type == "qwen2_moe":
         from ipex_llm.transformers.models.qwen2_moe import merge_qkv
         model.apply(merge_qkv)

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -734,7 +734,14 @@ def _optimize_pre(model):
     # for qwen2
     if model.config.model_type == "qwen2":
         from ipex_llm.transformers.models.qwen2 import merge_qkv
-        model.apply(merge_qkv)
+        # Skip merge_qkv if quant_method is 'gptq'
+        should_apply_merge_qkv = (
+            not hasattr(model.config, "quantization_config") or
+            not hasattr(model.config.quantization_config, "quant_method") or
+            model.config.quantization_config.quant_method != "gptq"
+        )
+        if should_apply_merge_qkv:
+            model.apply(merge_qkv)
         from ipex_llm.transformers.models.qwen2 import padding_mlp
         model.apply(padding_mlp)
     if model.config.model_type == "qwen2_moe":

--- a/python/llm/src/ipex_llm/transformers/models/qwen2.py
+++ b/python/llm/src/ipex_llm/transformers/models/qwen2.py
@@ -418,8 +418,10 @@ def qwen2_attention_forward(
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
         query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)                                                
+        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim) \
+                               .transpose(1, 2)
+        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim) \
+                                   .transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
     if past_key_value is not None:


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Fix user issue: https://github.com/intel-analytics/ipex-llm/issues/11413

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
No user api change. 

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
The weights of gptq have already been quantized. During the merge_qkv process in qwen2, we encounter an `AttributeError: 'QuantLinear' object has no attribute 'weight'. Did you mean: 'qweight'?` This PR skips merge_qkv for the qwen2 gptq model as a quick fix. We will submit another PR later to thoroughly resolve this issue.

### 4. How to test?
manually tested it

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->
No