### PR TITLE
change npu document

### DIFF
--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Model/llama2/README.md
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Model/llama2/README.md
@@ -20,12 +20,7 @@ conda activate llm
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 
 # below command will install intel_npu_acceleration_library
-conda install cmake
-git clone https://github.com/intel/intel-npu-acceleration-library npu-library
-cd npu-library
-git checkout bcb1315
-python setup.py bdist_wheel
-pip install dist\intel_npu_acceleration_library-1.2.0-cp310-cp310-win_amd64.whl
+pip install intel-npu-acceleration-library==1.3
 ```
 
 ### 2. Runtime Configurations
@@ -48,7 +43,7 @@ Arguments info:
 - `--repo-id-or-model-path REPO_ID_OR_MODEL_PATH`: argument defining the huggingface repo id for the Llama2 model (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded, or the path to the huggingface checkpoint folder. It is default to be `'meta-llama/Llama-2-7b-chat-hf'`.
 - `--prompt PROMPT`: argument defining the prompt to be infered (with integrated prompt format for chat). It is default to be `'Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun'`.
 - `--n-predict N_PREDICT`: argument defining the max number of tokens to predict. It is default to be `32`.
-- `--load_in_low_bit`: argument defining the load_in_low_bit format used. It is default to be `sym_int8`, `sym_int4` can also be used.
+- `--load_in_low_bit`: argument defining the `load_in_low_bit` format used. It is default to be `sym_int8`, `sym_int4` can also be used.
 
 #### Sample Output
 #### [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf)


### PR DESCRIPTION
## Description

intel-npu-acceleration-library has released 1.3, which contains int8 and int4 fix, so no need to compile it from source code

