### PR TITLE
Fix setting of `use_quantize_kv_cache` on different GPU in pipeline parallel

### DIFF
--- a/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
+++ b/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
@@ -107,7 +107,7 @@ def init_pipeline_parallel():
     dist.init_process_group('ccl')
 
 
-def _check_quantize_kv_cache(model, idx, batch_size) -> bool:
+def _check_quantize_kv_cache(model, idx, batch_size):
     # align use_quantize_kv_cache setting for different GPU in pipeline parallel
     pp_quantize_kv_cache = (os.environ.get("BIGDL_QUANTIZE_KV_CACHE", None) == "1") or \
         (os.environ.get("IPEX_LLM_QUANTIZE_KV_CACHE", None) == "1") or \

--- a/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
+++ b/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
@@ -120,9 +120,9 @@ def _check_quantize_kv_cache(model, idx, batch_size) -> bool:
         linear = model._modules['transformer'].encoder.layers[idx].self_attention.query_key_value
     else:
         linear = model._modules['model'].layers[idx].mlp.up_proj
-    pp_quantize_kv_cache = pp_quantize_kv_cache or (1 < batch_size and batch_size <= 8 and \
-                                                    hasattr(linear, "qtype") and \
-                                                    linear.qtype != ggml_tensor_qtype["fp16"] and \
+    pp_quantize_kv_cache = pp_quantize_kv_cache or (1 < batch_size and batch_size <= 8 and
+                                                    hasattr(linear, "qtype") and
+                                                    linear.qtype != ggml_tensor_qtype["fp16"] and
                                                     linear.qtype != ggml_tensor_qtype["bf16"])
     if pp_quantize_kv_cache:
         os.environ["IPEX_LLM_QUANTIZE_KV_CACHE"] = "1"

--- a/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
+++ b/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
@@ -27,6 +27,7 @@ from typing import Callable, List, Optional
 from types import SimpleNamespace
 from transformers import GenerationConfig, LogitsProcessorList, StoppingCriteriaList
 from ipex_llm.utils.common import invalidInputError
+from ipex_llm.ggml.quantize import ggml_tensor_qtype
 import logging
 logger = logging.getLogger(__name__)
 import asyncio
@@ -104,6 +105,29 @@ def init_pipeline_parallel():
     os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "127.0.0.1")
     os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "29500")
     dist.init_process_group('ccl')
+
+
+def _check_quantize_kv_cache(model, idx, batch_size) -> bool:
+    # align use_quantize_kv_cache setting for different GPU in pipeline parallel
+    pp_quantize_kv_cache = (os.environ.get("BIGDL_QUANTIZE_KV_CACHE", None) == "1") or \
+        (os.environ.get("IPEX_LLM_QUANTIZE_KV_CACHE", None) == "1") or \
+        (os.environ.get("IPEX_LLM_LOW_MEM", None) == "1")
+    if model.config.model_type == "qwen" and hasattr(model.config, "visual"):
+        # for Qwen-VL-Chat
+        linear = model._modules['transformer'].h[idx].mlp.c_proj
+    elif model.config.model_type == "chatglm":
+        # for chatglm3-6b, glm-4-9b-chat
+        linear = model._modules['transformer'].encoder.layers[idx].self_attention.query_key_value
+    else:
+        linear = model._modules['model'].layers[idx].mlp.up_proj
+    pp_quantize_kv_cache = pp_quantize_kv_cache or (1 < batch_size and batch_size <= 8 and \
+                                                    hasattr(linear, "qtype") and \
+                                                    linear.qtype != ggml_tensor_qtype["fp16"] and \
+                                                    linear.qtype != ggml_tensor_qtype["bf16"])
+    if pp_quantize_kv_cache:
+        os.environ["IPEX_LLM_QUANTIZE_KV_CACHE"] = "1"
+    else:
+        os.environ["IPEX_LLM_QUANTIZE_KV_CACHE"] = "0"
 
 
 def pipeline_parallel(model, pipeline_parallel_stages):
@@ -255,6 +279,7 @@ def pipeline_parallel_generate(self,
     _past_key_values = None
     bs = inputs.shape[0]
     output_ids = inputs.clone()
+    _check_quantize_kv_cache(self, layer_start, bs)
 
     step = 0
     # keep track of which sequences are already finished


### PR DESCRIPTION
## Description

When run llama2-13b & bs=2 using PP, exist following error:
```bash
attn_output = xe_addons.sdp_fp8(query_states, key_states, value_states, new_attn_mask)

                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

RuntimeError: expected scalar type Byte but found Half
```
The root cause is dummylayer don't have `qtype` attribute, then different value of `use_quantize_kv_cache` is obtained on `xpu0` and `xpu1` if env variable is not set.

Fix it in this PR. 

### 2. User API changes

N/A


### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/9805773757
- [x] Local test
