### PR TITLE
[ADD] add 5 new models for igpu-perf

### DIFF
--- a/python/llm/test/benchmark/igpu-perf/1024-128.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128.yaml
@@ -6,6 +6,10 @@ repo_id:
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - 'mistralai/Mistral-7B-Instruct-v0.2'
+  - 'openbmb/MiniCPM-1B-sft-bf16'
+  - 'openbmb/MiniCPM-2B-sft-bf16'
+  - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_437.yaml
@@ -2,6 +2,7 @@ repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
   - 'Qwen/Qwen2-7B-Instruct'
   - 'microsoft/Phi-3-mini-4k-instruct'
+  - 'microsoft/Phi-3-mini-128k-instruct'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16.yaml
@@ -6,6 +6,10 @@ repo_id:
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - 'mistralai/Mistral-7B-Instruct-v0.2'
+  - 'openbmb/MiniCPM-1B-sft-bf16'
+  - 'openbmb/MiniCPM-2B-sft-bf16'
+  - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_437.yaml
@@ -2,6 +2,7 @@ repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
   - 'Qwen/Qwen2-7B-Instruct'
   - 'microsoft/Phi-3-mini-4k-instruct'
+  - 'microsoft/Phi-3-mini-128k-instruct'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_loadlowbit.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_loadlowbit.yaml
@@ -6,6 +6,10 @@ repo_id:
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - 'mistralai/Mistral-7B-Instruct-v0.2'
+  - 'openbmb/MiniCPM-1B-sft-bf16'
+  - 'openbmb/MiniCPM-2B-sft-bf16'
+  - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_loadlowbit_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_loadlowbit_437.yaml
@@ -2,6 +2,7 @@ repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
   - 'Qwen/Qwen2-7B-Instruct'
   - 'microsoft/Phi-3-mini-4k-instruct'
+  - 'microsoft/Phi-3-mini-128k-instruct'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/2048-256_int4_fp16.yaml
+++ b/python/llm/test/benchmark/igpu-perf/2048-256_int4_fp16.yaml
@@ -6,6 +6,10 @@ repo_id:
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - 'mistralai/Mistral-7B-Instruct-v0.2'
+  - 'openbmb/MiniCPM-1B-sft-bf16'
+  - 'openbmb/MiniCPM-2B-sft-bf16'
+  - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/2048-256_int4_fp16_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/2048-256_int4_fp16_437.yaml
@@ -2,6 +2,7 @@ repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
   - 'Qwen/Qwen2-7B-Instruct'
   - 'microsoft/Phi-3-mini-4k-instruct'
+  - 'microsoft/Phi-3-mini-128k-instruct'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/igpu-perf/32-32_int4_fp16.yaml
+++ b/python/llm/test/benchmark/igpu-perf/32-32_int4_fp16.yaml
@@ -6,6 +6,10 @@ repo_id:
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'meta-llama/Llama-2-13b-chat-hf'
   - 'meta-llama/Meta-Llama-3-8B-Instruct'
+  - 'mistralai/Mistral-7B-Instruct-v0.2'
+  - 'openbmb/MiniCPM-1B-sft-bf16'
+  - 'openbmb/MiniCPM-2B-sft-bf16'
+  - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
 local_model_hub: 'path to your local model hub'
 warm_up: 3
 num_trials: 5

--- a/python/llm/test/benchmark/igpu-perf/32-32_int4_fp16_437.yaml
+++ b/python/llm/test/benchmark/igpu-perf/32-32_int4_fp16_437.yaml
@@ -2,6 +2,7 @@ repo_id:
   - 'Qwen/Qwen1.5-7B-Chat'
   - 'Qwen/Qwen2-7B-Instruct'
   - 'microsoft/Phi-3-mini-4k-instruct'
+  - 'microsoft/Phi-3-mini-128k-instruct'
 local_model_hub: 'path to your local model hub'
 warm_up: 3
 num_trials: 5


### PR DESCRIPTION
## Description
Add 5 new models for igpu-perf

transformer4.36.2:
  - 'mistralai/Mistral-7B-Instruct-v0.2'
  - 'openbmb/MiniCPM-1B-sft-bf16'
  - 'openbmb/MiniCPM-2B-sft-bf16'
  - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
  
transformer4.37.0:
  - 'microsoft/Phi-3-mini-128k-instruct'