### PR TITLE
remove upload_to_sourceforge logic 

### DIFF
--- a/python/llm/dev/release.sh
+++ b/python/llm/dev/release.sh
@@ -75,11 +75,4 @@ if [ ${upload} == true ]; then
     upload_to_pypi_command="twine upload dist/ipex_llm-${ipex_llm_version}-*-${verbose_pname}.whl"
     echo "Please manually upload with this command: $upload_to_pypi_command"
     $upload_to_pypi_command
-
-    # upload to sourceforge
-    rsync -avzr -e \
-    "sshpass -p '${SOURCEFORGE_PW}' ssh -o StrictHostKeyChecking=no" \
-    ./dist/ipex_llm-${ipex_llm_version}-*-${verbose_pname}.whl \
-    intelanalytics@frs.sourceforge.net:/home/frs/project/analytics-zoo/ipex-llm-whl/ipex-llm/${ipex_llm_version}/
-
 fi


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission remove upload_to_sourceforge logic since we migrate backup_to_sourceforge.yml to ipex-llm-workflow repo: https://github.com/intel-analytics/ipex-llm-workflow/blob/main/.github/workflows/backup_to_sourceforge.yml to upload both ipex-llm and core-xe wheels
