### PR TITLE
add model RWKV/v5-Eagle-7B-HF to igpu benchmark

### DIFF
--- a/python/llm/test/benchmark/igpu-perf/1024-128.yaml
+++ b/python/llm/test/benchmark/igpu-perf/1024-128.yaml
@@ -10,6 +10,7 @@ repo_id:
   - 'openbmb/MiniCPM-1B-sft-bf16'
   - 'openbmb/MiniCPM-2B-sft-bf16'
   - 'deepseek-ai/deepseek-coder-7b-instruct-v1.5'
+  - 'RWKV/v5-Eagle-7B-HF'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3


### PR DESCRIPTION
This model only support fp32, so we only add it to [1024-128.yaml](https://github.com/intel-analytics/ipex-llm/compare/main...ATMxsp01:benchmark-update-mtl?expand=1#diff-e1acf6d95ddd9da5f34e2dc3cf192dfb14998b067324605e62ea8a996a359c50)