### PR TITLE
LLM: Fix /generate_stream api in Pipeline Parallel FastAPI

### DIFF
--- a/python/llm/example/GPU/Pipeline-Parallel-FastAPI/pipeline_serving.py
+++ b/python/llm/example/GPU/Pipeline-Parallel-FastAPI/pipeline_serving.py
@@ -192,7 +192,6 @@ async def generate(prompt_request: PromptRequest):
             return request_id, "".join(output_str)
 
 
-@app.post("/generate_stream/")
 async def generate_stream(prompt_request: PromptRequest):
     request_id = str(uuid.uuid4()) + "stream"
     await local_model.waiting_requests.put((request_id, prompt_request))
@@ -210,6 +209,11 @@ async def generate_stream(prompt_request: PromptRequest):
             return request_id, StreamingResponse(
                 content=cur_generator, media_type="text/event-stream"
             )
+
+@app.post("/generate_stream/")
+async def generate_stream_api(prompt_request: PromptRequest):
+    request_id, result = await generate_stream(prompt_request)
+    return result
 
 
 DEFAULT_SYSTEM_PROMPT = """\


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
Not return request_id for a stream api responce.

### 4. How to test?
- [x] Local test
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
