### PR TITLE
Quickstart edits

### DIFF
--- a/docs/mddocs/Quickstart/README.md
+++ b/docs/mddocs/Quickstart/README.md
@@ -1,7 +1,7 @@
 # IPEX-LLM Quickstart
 
 > [!NOTE]
-> We are adding more Quickstart guide.
+> We are adding more Quickstart guides.
 
 This section includes efficient guide to show you how to:
 

--- a/docs/mddocs/Quickstart/ollama_quickstart.md
+++ b/docs/mddocs/Quickstart/ollama_quickstart.md
@@ -148,10 +148,12 @@ Ollama supports importing GGUF models in the Modelfile, for example, suppose you
 ```bash
 FROM ./mistral-7b-instruct-v0.1.Q4_K_M.gguf
 TEMPLATE [INST] {{ .Prompt }} [/INST]
-PARAMETER num_predict 64
+PARAMETER num_predict 1024
 ```
 
 Then you can create the model in Ollama by `ollama create example -f Modelfile` and use `ollama run` to run the model directly on console.
+> [!NOTE]  
+> If you get an incomplete response, consider adjusting the `num_predict` parameter to a higher number such as 2048 or 4096.
 
 - For **Linux users**:
   


### PR DESCRIPTION
The num_predict parameter in Ollama Quickstart guide is too low for general use, 1096 is a better option. I also added a note to allow user customization if they see fit. 
