### PR TITLE
add disk embedding api

### DIFF
--- a/python/llm/src/ipex_llm/transformers/embedding.py
+++ b/python/llm/src/ipex_llm/transformers/embedding.py
@@ -88,10 +88,11 @@ class DiskEmbedding(torch.nn.Embedding):
                  sparse: bool = False,
                  _weight: Optional[Tensor] = None,
                  _freeze: bool = False,
-                 device=None, dtype=None) -> None:
+                 device=None,
+                 dtype=None):
         super().__init__(num_embeddings, embedding_dim, padding_idx,
                          max_norm, norm_type, scale_grad_by_freq,
-                         sparse, _weight, _freeze, device, dtype)
+                         sparse, _weight, True, device, dtype)
         self.filename = "embeddings.bin"
         self.weight.data.flatten().half().numpy().tofile(self.filename)
         dummy_weight = torch.empty(0, 0, dtype=self.weight.dtype, device=self.weight.device)
@@ -117,6 +118,22 @@ class DiskEmbedding(torch.nn.Embedding):
             device=self.weight.device, dtype=self.weight.dtype
         )
         self.weight = torch.nn.Parameter(embeds, requires_grad=False)
+
+    @classmethod
+    def from_embedding(cls, embedding: torch.nn.Embedding):
+        return cls(
+            embedding.num_embeddings,
+            embedding.embedding_dim,
+            embedding.padding_idx,
+            embedding.max_norm,
+            embedding.norm_type,
+            embedding.scale_grad_by_freq,
+            embedding.sparse,
+            embedding.weight.data,
+            True,
+            embedding.weight.device,
+            embedding.weight.dtype,
+        )
 
 
 class LowBitEmbedding(torch.nn.Embedding):


### PR DESCRIPTION
## Description

add disk embedding api



### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

take qwen2 as an example:

```python
from ipex_llm.transformers.embedding import AutoModelForCausalLM, DiskEmbedding

model = AutoModelForCausalLM.from_pretrained(xxx)

model.model.embed_tokens = DiskEmbedding.from_embedding(model.model.embed_tokens)
```

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...
