### PR TITLE
LLM: Fix ParallelLMHead convert in vLLM cpu

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -153,8 +153,9 @@ def is_linear_module(module):
         VLLM_LINEAR_LIST = [
             ColumnParallelLinear, RowParallelLinear, QKVParallelLinear,
             MergedColumnParallelLinear,
-            ParallelLMHead
         ]
+        if 'xpu' in _VLLM_VERSION:
+            VLLM_LINEAR_LIST.append(ParallelLMHead)
         if is_module_in_classes(module, VLLM_LINEAR_LIST):
             if 'xpu' in _VLLM_VERSION:
                 # For vllm xpu


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

Current `ParallelLMHead` convert is only set on XPU and will crush on CPU. Remove `ParallelLMHead` from VLLM_LINEAR_LIST for CPU.

### 4. How to test?
- [ ] Local test
