### PR TITLE
Change logic for detecting if vllm is available

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -70,12 +70,7 @@ def is_vllm_available():
     global _IS_VLLM_AVAILABLE
     if _IS_VLLM_AVAILABLE is not None:
         return _IS_VLLM_AVAILABLE
-    reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'list'])
-    installed_packages = [r.decode().split('  ')[0] for r in reqs.split()]
-    if 'vllm' in installed_packages:
-        _IS_VLLM_AVAILABLE = True
-    else:
-        _IS_VLLM_AVAILABLE = False
+    _IS_VLLM_AVAILABLE = importlib.util.find_spec("vllm") is not None
     return _IS_VLLM_AVAILABLE
 
 

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -70,7 +70,12 @@ def is_vllm_available():
     global _IS_VLLM_AVAILABLE
     if _IS_VLLM_AVAILABLE is not None:
         return _IS_VLLM_AVAILABLE
+    import sys
+    original_path = sys.path
+    # Temporally remove current directory
+    sys.path = [p for p in sys.path if p != '']
     _IS_VLLM_AVAILABLE = importlib.util.find_spec("vllm") is not None
+    sys.path = original_path
     return _IS_VLLM_AVAILABLE
 
 


### PR DESCRIPTION
## Description

Change logic for detecting if vllm is available.

The original method is to avoid the condition where the vllm folder exists in the current directory, but not installed.

This condition is quite rare.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
