### PR TITLE
empty cache only for 1st token but rest token to speed up

### DIFF
--- a/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
+++ b/python/llm/src/ipex_llm/transformers/pipeline_parallel.py
@@ -959,9 +959,13 @@ def llama_causallm_forward_4_37_lowmem(
         logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.config.pretraining_tp)]  # noqa
         logits = torch.cat(logits, dim=-1)
     else:
-        torch.xpu.empty_cache()
+        # Only empty cache for first token
+        if hidden_states.shape[1] > 1:
+            torch.xpu.empty_cache()
         logits = self.lm_head(hidden_states)
-        torch.xpu.empty_cache()
+        # Only empty cache for first token
+        if hidden_states.shape[1] > 1:
+            torch.xpu.empty_cache()
     # logits = logits.float()
 
     # ipex-llm change ends


### PR DESCRIPTION
## Description

Work with @qiyuangong 

No need to empty cache for rest token, which also introduces much latency overhead in llama's low-memory forward

### 1. Why the change?

as above

### 2. User API changes

no

### 3. Summary of the change 

empty cache only for 1st token but rest token to speed up

### 4. How to test?
- [ ] N/A
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] Application test
- [ ] Document test
- [ ] ...
