### PR TITLE
Fix import vllm condition

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -73,7 +73,7 @@ def is_vllm_available():
     import sys
     original_path = sys.path
     # Temporally remove current directory
-    sys.path = [p for p in sys.path if p != '']
+    sys.path = original_path[1:]
     _IS_VLLM_AVAILABLE = importlib.util.find_spec("vllm") is not None
     sys.path = original_path
     return _IS_VLLM_AVAILABLE


### PR DESCRIPTION
## Description

In python script, the first '' will be converted to current directory.  The possible option is to remove the first one.

The path added by modifying PYTHONPATH will be second entry.