### PR TITLE
add fallback for unsupported k-quants

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -395,7 +395,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                         if cur_qtype in [ggml_tensor_qtype["sym_int4"],
                                          ggml_tensor_qtype["asym_int4"]]:
                             cur_qtype = ggml_tensor_qtype["sym_int8"]
-                    
+
                     # check hidden size whether is a multiple of 256
                     cur_qtype = check_hidden_size(cur_qtype, in_features)
 

--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -44,7 +44,7 @@ import warnings
 import transformers
 import importlib.util
 from ipex_llm.ggml.quantize import ggml_tensor_qtype, gguf_mixed_qtype
-from .utils import logger, get_cur_qtype_and_imatrix
+from .utils import logger, get_cur_qtype_and_imatrix, check_hidden_size
 import numpy as np
 import os
 from ipex_llm.utils.common import invalidInputError
@@ -395,6 +395,9 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                         if cur_qtype in [ggml_tensor_qtype["sym_int4"],
                                          ggml_tensor_qtype["asym_int4"]]:
                             cur_qtype = ggml_tensor_qtype["sym_int8"]
+                    
+                    # check hidden size whether is a multiple of 256
+                    cur_qtype = check_hidden_size(cur_qtype, in_features)
 
                     new_linear = LowBitLinear(
                         in_features,

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -361,3 +361,24 @@ def get_modelscope_hf_config(model_id_or_path: str,
 def is_torch_bf16_gpu_available():
     # always true for XPU and CPU
     return True
+
+def check_hidden_size(qtype, hidden_size):
+    if hidden_size % 256 != 0:
+        if qtype == ggml_tensor_qtype["q4_k"]:
+            logger.info(f"hidden size {hidden_size} is not divisible by 256, "
+                        "required for q4_k - using fallback quantization asym_int4.")
+            return  ggml_tensor_qtype["asym_int4"]
+        elif qtype == ggml_tensor_qtype["q5_k"]:
+            logger.info(f"hidden size {hidden_size} is not divisible by 256, "
+                        "required for q5_k - using fallback quantization asym_int5.")
+            return  ggml_tensor_qtype["asym_int5"]
+        elif qtype == ggml_tensor_qtype["q6_k"]:
+            logger.info(f"hidden size {hidden_size} is not divisible by 256, "
+                        "required for q6_k - using fallback quantization sym_int8.")
+            return  ggml_tensor_qtype["sym_int8"]
+        elif qtype == ggml_tensor_qtype["fp6_k"]:
+            logger.info(f"hidden size {hidden_size} is not divisible by 256, "
+                        "required for fq6_k - using fallback quantization fp6.")
+            return  ggml_tensor_qtype["fp6"]
+    else:
+        return qtype

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -362,23 +362,24 @@ def is_torch_bf16_gpu_available():
     # always true for XPU and CPU
     return True
 
+
 def check_hidden_size(qtype, hidden_size):
     if hidden_size % 256 != 0:
         if qtype == ggml_tensor_qtype["q4_k"]:
             logger.info(f"hidden size {hidden_size} is not divisible by 256, "
                         "required for q4_k - using fallback quantization asym_int4.")
-            return  ggml_tensor_qtype["asym_int4"]
+            return ggml_tensor_qtype["asym_int4"]
         elif qtype == ggml_tensor_qtype["q5_k"]:
             logger.info(f"hidden size {hidden_size} is not divisible by 256, "
                         "required for q5_k - using fallback quantization asym_int5.")
-            return  ggml_tensor_qtype["asym_int5"]
+            return ggml_tensor_qtype["asym_int5"]
         elif qtype == ggml_tensor_qtype["q6_k"]:
             logger.info(f"hidden size {hidden_size} is not divisible by 256, "
                         "required for q6_k - using fallback quantization sym_int8.")
-            return  ggml_tensor_qtype["sym_int8"]
+            return ggml_tensor_qtype["sym_int8"]
         elif qtype == ggml_tensor_qtype["fp6_k"]:
             logger.info(f"hidden size {hidden_size} is not divisible by 256, "
                         "required for fq6_k - using fallback quantization fp6.")
-            return  ggml_tensor_qtype["fp6"]
+            return ggml_tensor_qtype["fp6"]
     else:
         return qtype

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -381,5 +381,4 @@ def check_hidden_size(qtype, hidden_size):
             logger.info(f"hidden size {hidden_size} is not divisible by 256, "
                         "required for fq6_k - using fallback quantization fp6.")
             return ggml_tensor_qtype["fp6"]
-    else:
-        return qtype
+    return qtype


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/1403#issuecomment-2259456670

### 2. User API changes

No change, just add fallback for unsupported k-quants

### 3. Summary of the change 

 add fallback precisons for unsupported k-quants


### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.

### Demo output for chatglm3-6b
```bash
2024-07-31 10:50:15,943 - INFO - hidden size 13696 is not divisible by 256, required for q4_k - using fallback quantization asym_int4.
2024-07-31 10:50:17,181 - INFO - hidden size 13696 is not divisible by 256, required for q4_k - using fallback quantization asym_int4.
2024-07-31 10:50:18,465 - INFO - hidden size 13696 is not divisible by 256, required for q4_k - using fallback quantization asym_int4.
2024-07-31 10:50:19,744 - INFO - hidden size 13696 is not divisible by 256, required for q4_k - using fallback quantization asym_int4.
2024-07-31 10:50:21,024 - INFO - hidden size 13696 is not divisible by 256, required for q4_k - using fallback quantization asym_int4.
```