### PR TITLE
Add RANK_WAIT_TIME into DeepSpeed-AutoTP to avoid CPU memory OOM

### DIFF
--- a/python/llm/example/GPU/Deepspeed-AutoTP/README.md
+++ b/python/llm/example/GPU/Deepspeed-AutoTP/README.md
@@ -87,4 +87,4 @@ bash run_mistral_7b_instruct_flex_2_card.sh
 ### Known Issue
 
 - In our example scripts, tcmalloc is enabled through `export LD_PRELOAD=${LD_PRELOAD}:${CONDA_PREFIX}/lib/libtcmalloc.so:${LD_PRELOAD}` which speed up inference, but this may raise `munmap_chunk(): invalid pointer` error after finishing inference.
-- CPU memory OOM during model covert. In this example, multiple processors will loading models into memory at the same time. If model size/rank_num is very large, it will lead to OOM. Please increase `RANK_WAIT_TIME` to avoid using too much memory.
+- CPU memory OOM during model covert. In this example, multiple processors will loading models into memory at the same time. If model size/rank_num is very large, it will lead to OOM. Please `export RANK_WAIT_TIME=xxx`. `xxx` is sleep time in seconds. You can increase `RANK_WAIT_TIME` to avoid using too much memory.

--- a/python/llm/example/GPU/Deepspeed-AutoTP/README.md
+++ b/python/llm/example/GPU/Deepspeed-AutoTP/README.md
@@ -87,3 +87,4 @@ bash run_mistral_7b_instruct_flex_2_card.sh
 ### Known Issue
 
 - In our example scripts, tcmalloc is enabled through `export LD_PRELOAD=${LD_PRELOAD}:${CONDA_PREFIX}/lib/libtcmalloc.so:${LD_PRELOAD}` which speed up inference, but this may raise `munmap_chunk(): invalid pointer` error after finishing inference.
+- CPU memory OOM during model covert. In this example, multiple processors will loading models into memory at the same time. If model size/rank_num is very large, it will lead to OOM. Please increase `RANK_WAIT_TIME` to avoid using too much memory.

--- a/python/llm/example/GPU/Deepspeed-AutoTP/deepspeed_autotp.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP/deepspeed_autotp.py
@@ -66,6 +66,11 @@ if __name__ == '__main__':
     # Convert to deepspeed model and apply IPEX-LLM optimization on CPU to decrease GPU memory usage
     current_accel = CPU_Accelerator()
     set_accelerator(current_accel)
+    # Avoid OOM caused by parallel loading models into CPU memory
+    # Please increase RANK_WAIT_TIME to avoid using too much memory.
+    rank_wait_time = os.environ.get("RANK_WAIT_TIME", 0)
+    if rank_wait_time != 0:
+        time.sleep(local_rank * rank_wait_time)
     model = AutoModelForCausalLM.from_pretrained(args.repo_id_or_model_path,
                                                  device_map={"": "cpu"},
                                                  low_cpu_mem_usage=True,


### PR DESCRIPTION
## Description

DeepSpeed-AutoTP will start multiple processors to load models and convert them in the CPU memory. That will lead to OOM if model/rank_num is large.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
