### PR TITLE
Remove Out of tree Driver from GPU driver installation document

### DIFF
--- a/docs/mddocs/Quickstart/install_linux_gpu.md
+++ b/docs/mddocs/Quickstart/install_linux_gpu.md
@@ -39,7 +39,7 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
         dkms \
         linux-headers-$(uname -r) \
         libc6-dev
-    sudo apt install intel-i915-dkms intel-fw-gpu
+
     sudo apt-get install -y gawk libc6-dev udev\
         intel-opencl-icd intel-level-zero-gpu level-zero \
         intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
@@ -94,14 +94,21 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
         libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
         libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
         mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo
-    
-    sudo apt install -y intel-i915-dkms intel-fw-gpu
-
+  
     sudo reboot
     ```
 
     <img src="https://llm-assets.readthedocs.io/en/latest/_images/gawk.png" width=100%; />
 
+* Configure permissions
+    ```bash
+    sudo gpasswd -a ${USER} render
+    newgrp render
+
+    # Verify the device is working with i915 driver
+    sudo apt-get install -y hwinfo
+    hwinfo --display
+    ```
 
 #### (Optional) Update Level Zero on Intel Core™ Ultra iGPU
 For Intel Core™ Ultra integrated GPU, please make sure level_zero version >= 1.3.28717. The level_zero version can be checked with `sycl-ls`, and verison will be tagged behind `[ext_oneapi_level_zero:gpu]`.

--- a/docs/mddocs/Quickstart/install_linux_gpu.md
+++ b/docs/mddocs/Quickstart/install_linux_gpu.md
@@ -60,7 +60,7 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
     sudo gpasswd -a ${USER} render
     newgrp render
 
-    # Verify the device is working with i915 driver
+    # Verify the device is working with i915 driver
     sudo apt-get install -y hwinfo
     hwinfo --display
     ```
@@ -105,7 +105,7 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
     sudo gpasswd -a ${USER} render
     newgrp render
 
-    # Verify the device is working with i915 driver
+    # Verify the device is working with i915 driver
     sudo apt-get install -y hwinfo
     hwinfo --display
     ```

--- a/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/install_linux_gpu.md
@@ -30,14 +30,14 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
         dkms \
         linux-headers-$(uname -r) \
         libc6-dev
-    sudo apt install intel-i915-dkms intel-fw-gpu
+
     sudo apt-get install -y gawk libc6-dev udev\
         intel-opencl-icd intel-level-zero-gpu level-zero \
         intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
         libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
         libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
         mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo
-    
+
     sudo reboot
     ```
 
@@ -51,7 +51,7 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
     sudo gpasswd -a ${USER} render
     newgrp render
 
-    # Verify the device is working with i915 driver
+    # Verify the device is working with i915 driver
     sudo apt-get install -y hwinfo
     hwinfo --display
     ```
@@ -85,14 +85,21 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
         libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
         libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
         mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo
-    
-    sudo apt install -y intel-i915-dkms intel-fw-gpu
 
     sudo reboot
     ```
 
     <img src="https://llm-assets.readthedocs.io/en/latest/_images/gawk.png" width=100%; />
 
+* Configure permissions
+    ```bash
+    sudo gpasswd -a ${USER} render
+    newgrp render
+
+    # Verify the device is working with i915 driver
+    sudo apt-get install -y hwinfo
+    hwinfo --display
+    ```
 
 #### (Optional) Update Level Zero on Intel Core™ Ultra iGPU
 For Intel Core™ Ultra integrated GPU, please make sure level_zero version >= 1.3.28717. The level_zero version can be checked with `sycl-ls`, and verison will be tagged behind `[ext_oneapi_level_zero:gpu]`.


### PR DESCRIPTION
## Description

GPU drivers are already upstreamed to Kernel 6.2+. Remove the out-of-tree driver (intel-i915-dkms) for 6.2-6.5. https://dgpu-docs.intel.com/driver/kernel-driver-types.html#gpu-driver-support

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
