### PR TITLE
optimize lookahead init time

### DIFF
--- a/python/llm/example/GPU/HuggingFace/LLM/qwen2/generate.py
+++ b/python/llm/example/GPU/HuggingFace/LLM/qwen2/generate.py
@@ -19,7 +19,6 @@ import time
 import argparse
 
 from transformers import AutoTokenizer
-from ipex_llm import optimize_model
 import numpy as np
 
 
@@ -36,7 +35,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     model_path = args.repo_id_or_model_path
 
-    
+
     from ipex_llm.transformers import AutoModelForCausalLM
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
@@ -45,7 +44,7 @@ if __name__ == '__main__':
                                                  optimize_model=True,
                                                  trust_remote_code=True,
                                                  use_cache=True)
-    model = model.to("xpu")
+    model = model.half().to("xpu")
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path,

--- a/python/llm/src/ipex_llm/transformers/lookup.py
+++ b/python/llm/src/ipex_llm/transformers/lookup.py
@@ -149,7 +149,7 @@ class PromptLookupCandidateGenerator():
                            input_ids: torch.LongTensor):
         for ngram_size in range(self.max_matching_ngram_size, 0, -1):
             # Create sliding windows of size ngram_size
-            windows = input_ids.unfold(dimension=1, size=ngram_size, step=1)
+            windows = input_ids.cpu().unfold(dimension=1, size=ngram_size, step=1)
             for idx in range(windows.size(1)):
                 window = tensor2key(windows[0, idx])
                 if window not in self.lookup_table:


### PR DESCRIPTION
## Description

### 1. Why the change?

- fix abnormal first token time of lookahead
- update qwen2 exmaple to use fp14+int4

### 2. User API changes

No.

### 3. Summary of the change 

- fix abnormal first token time of lookahead
   4k baseline time: 5999.75
   lookahead time: 10181.13
   with this PR, lookahead time: 6056.97

### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
