### PR TITLE
Fix stdout in all-in-one benchmark to utf-8

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/run.py
+++ b/python/llm/dev/benchmark/all-in-one/run.py
@@ -29,6 +29,8 @@ from datetime import date
 import os
 current_dir = os.path.dirname(os.path.realpath(__file__))
 import sys
+sys.stdout.reconfigure(encoding='utf-8')
+
 from ipex_llm.utils import BenchmarkWrapper
 from ipex_llm.utils.common.log4Error import invalidInputError
 from ipex_llm.utils.common import invalidInputError


### PR DESCRIPTION
## Description

Fix stdout in all-in-one benchmark to utf-8. This should fix bug in workflow https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/10355795172/job/28682779918
