### PR TITLE
fix gemma2 runtime error caused by sliding window

### DIFF
--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -1207,35 +1207,32 @@ jobs:
 
           call conda deactivate
 
-      # NOTE: Gemma2 not working for 4096-512. 
-      #       When it works, uncomment this section and remember to change "'s/{today}_test3/{today}_test1/g'" in next section.
-      
-      #- name: Prepare igpu perf test for transformers 4.43 (4096-512 int4+fp16)
-      #  shell: bash
-      #  run: |
-      #    sed -i 's/{today}_test3/{today}_test4/g' python/llm/dev/benchmark/all-in-one/run.py
-      #    sed -i "s/path to your local model hub/$MODEL_HUB_DIR/g" python/llm/test/benchmark/igpu-perf/4096-512_int4_fp16_443.yaml
+      - name: Prepare igpu perf test for transformers 4.43 (4096-512 int4+fp16)
+       shell: bash
+       run: |
+         sed -i 's/{today}_test3/{today}_test4/g' python/llm/dev/benchmark/all-in-one/run.py
+         sed -i "s/path to your local model hub/$MODEL_HUB_DIR/g" python/llm/test/benchmark/igpu-perf/4096-512_int4_fp16_443.yaml
 
-      #- name: Test on igpu for transformers 4.43 (4096-512 int4+fp16)
-      #  shell: cmd
-      #  run: |
-      #    call conda activate igpu-perf
-      #    pip install transformers==4.43.1
-      #    pip install trl
-      #
-      #    set SYCL_CACHE_PERSISTENT=1
-      #    set BIGDL_LLM_XMX_DISABLED=1
-      #
-      #    cd python\llm\dev\benchmark\all-in-one
-      #    move ..\..\..\test\benchmark\igpu-perf\4096-512_int4_fp16_443.yaml config.yaml
-      #    set PYTHONIOENCODING=utf-8
-      #    python run.py >> %CSV_SAVE_PATH%\4096-512_int4_fp16\log\%LOG_FILE% 2>&1
-      #    if %ERRORLEVEL% neq 0 (exit /b 1)
-      #    python ..\..\..\test\benchmark\igpu-perf\check_csv_results.py --yaml-file config.yaml --suffix test4
-      #    if %ERRORLEVEL% neq 0 (exit /b 1)
-      #    
-      #    pip uninstall trl -y
-      #    call conda deactivate
+      - name: Test on igpu for transformers 4.43 (4096-512 int4+fp16)
+       shell: cmd
+       run: |
+         call conda activate igpu-perf
+         pip install transformers==4.43.1
+         pip install trl
+      
+         set SYCL_CACHE_PERSISTENT=1
+         set BIGDL_LLM_XMX_DISABLED=1
+      
+         cd python\llm\dev\benchmark\all-in-one
+         move ..\..\..\test\benchmark\igpu-perf\4096-512_int4_fp16_443.yaml config.yaml
+         set PYTHONIOENCODING=utf-8
+         python run.py >> %CSV_SAVE_PATH%\4096-512_int4_fp16\log\%LOG_FILE% 2>&1
+         if %ERRORLEVEL% neq 0 (exit /b 1)
+         python ..\..\..\test\benchmark\igpu-perf\check_csv_results.py --yaml-file config.yaml --suffix test4
+         if %ERRORLEVEL% neq 0 (exit /b 1)
+         
+         pip uninstall trl -y
+         call conda deactivate
 
       - name: Concat csv and generate html (4096-512 int4+fp16)
         shell: cmd
@@ -1259,7 +1256,7 @@ jobs:
         shell: bash
         run: |
           sed -i 's/4096-512/1024-128/g' python/llm/dev/benchmark/all-in-one/run.py
-          sed -i 's/{today}_test3/{today}_test1/g' python/llm/dev/benchmark/all-in-one/run.py
+          sed -i 's/{today}_test4/{today}_test1/g' python/llm/dev/benchmark/all-in-one/run.py
           sed -i "s/path to your local model hub/$MODEL_HUB_DIR/g" python/llm/test/benchmark/igpu-perf/1024-128_int4_fp16_loadlowbit.yaml
 
       - name: Test on igpu (load_low_bit 1024-128 int4+fp16)


### PR DESCRIPTION
## Description


### 1. Why the change?

https://github.com/intel-analytics/ipex-llm/pull/11758
we found gemma2 will raise error when context is longer than sliding window size.

### 2. User API changes

No change.

### 3. Summary of the change 

- Fix sdp logic of gemma2 to handle with sliding window

### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
