### PR TITLE
Remove 4k igpu perf on gemma-2-9b-it

### DIFF
--- a/python/llm/test/benchmark/igpu-perf/4096-512_int4_fp16_443.yaml
+++ b/python/llm/test/benchmark/igpu-perf/4096-512_int4_fp16_443.yaml
@@ -1,6 +1,6 @@
 repo_id:
   - 'google/gemma-2-2b-it'
-  - 'google/gemma-2-9b-it'
+  # - 'google/gemma-2-9b-it'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3


### PR DESCRIPTION
## Description

Remove 4k igpu perf on gemma-2-9b-it
https://github.com/analytics-zoo/nano/issues/1547#issuecomment-2291003648
https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/10399268028/job/28797889229
