### PR TITLE
Remove gemma-2-9b-it 3k input from igpu-perf

### DIFF
--- a/python/llm/test/benchmark/igpu-perf/3072-384_int4_fp16_443.yaml
+++ b/python/llm/test/benchmark/igpu-perf/3072-384_int4_fp16_443.yaml
@@ -1,6 +1,6 @@
 repo_id:
   - 'google/gemma-2-2b-it'
-  - 'google/gemma-2-9b-it'
+  # - 'google/gemma-2-9b-it'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3


### PR DESCRIPTION
## Description

Remove gemma-2-9b-it 3k input from igpu-perf to make the test more stable
https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/10397601295/job/28793569345
https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/10407144562/attempts/1
https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/10397601295/job/28793569345
