### PR TITLE
delete transformers version requirement

### DIFF
--- a/python/llm/example/GPU/HuggingFace/LLM/internlm2/README.md
+++ b/python/llm/example/GPU/HuggingFace/LLM/internlm2/README.md
@@ -14,7 +14,6 @@ conda create -n llm python=3.11
 conda activate llm
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-pip install transformers==4.38.0
 pip install einops
 pip install huggingface_hub 
 ```

--- a/python/llm/example/GPU/HuggingFace/LLM/internlm2/README.md
+++ b/python/llm/example/GPU/HuggingFace/LLM/internlm2/README.md
@@ -26,7 +26,6 @@ conda activate llm
 
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade ipex-llm[xpu] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-pip install transformers==4.38.0
 pip install einops
 pip install huggingface_hub 
 ```


### PR DESCRIPTION
It is tested that transformers==4.38 doesn't work on the latest internlm2-chat-7b model. So the specification of 4.38 is deleted.