### PR TITLE
Add ipex-llm npu option in setup.py

### DIFF
--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/README.md
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/README.md
@@ -91,11 +91,8 @@ We suggest using conda to manage environment:
 conda create -n llm python=3.10
 conda activate llm
 
-# install ipex-llm with 'all' option
-pip install --pre --upgrade ipex-llm[all]
-pip install --pre --upgrade bigdl-core-npu
-
-pip install transformers==4.40
+# install ipex-llm with 'npu' option
+pip install --pre --upgrade ipex-llm[npu]
 ```
 
 ### 2. Runtime Configurations

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -305,7 +305,7 @@ def setup_package():
     for exclude_require in cpu_transformers_version:
         npu_requires.remove(exclude_require)
     npu_requires += ["transformers==4.40.0",
-                     "bigdl-core-npu==" + CORE_XE_VERSION]
+                     "bigdl-core-npu==" + CORE_XE_VERSION + ";platform_system=='Windows'"]
 
     metadata = dict(
         name='ipex_llm',

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -53,7 +53,7 @@ libs_dir = os.path.join(llm_home, "ipex_llm", "libs")
 
 cpu_torch_version = ["torch==2.1.2+cpu;platform_system=='Linux'", "torch==2.1.2;platform_system=='Windows'"]
 CONVERT_DEP = ['numpy == 1.26.4', # lastet 2.0.0b1 will cause error
-               'transformers == 4.37.0', 'sentencepiece', 'tokenizers == 0.15.2',
+               'transformers == 4.36.2', 'sentencepiece', 'tokenizers == 0.15.2',
                'accelerate == 0.23.0', 'tabulate'] + cpu_torch_version
 
 SERVING_DEP = ['fschat[model_worker, webui] == 0.2.36', 'protobuf']
@@ -301,7 +301,7 @@ def setup_package():
     serving_requires += SERVING_DEP
 
     npu_requires = copy.deepcopy(all_requires)
-    cpu_transformers_version = ['transformers == 4.37.0', 'tokenizers == 0.15.2']
+    cpu_transformers_version = ['transformers == 4.36.2', 'tokenizers == 0.15.2']
     for exclude_require in cpu_transformers_version:
         npu_requires.remove(exclude_require)
     npu_requires += ["transformers==4.40.0",

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -301,7 +301,7 @@ def setup_package():
     serving_requires += SERVING_DEP
 
     npu_requires = copy.deepcopy(all_requires)
-    cpu_transformers_version = ['transformers == 4.36.2', 'tokenizers == 0.15.2']
+    cpu_transformers_version = ['transformers == 4.37.0', 'tokenizers == 0.15.2']
     for exclude_require in cpu_transformers_version:
         npu_requires.remove(exclude_require)
     npu_requires += ["transformers==4.40.0",

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -53,7 +53,7 @@ libs_dir = os.path.join(llm_home, "ipex_llm", "libs")
 
 cpu_torch_version = ["torch==2.1.2+cpu;platform_system=='Linux'", "torch==2.1.2;platform_system=='Windows'"]
 CONVERT_DEP = ['numpy == 1.26.4', # lastet 2.0.0b1 will cause error
-               'transformers == 4.36.2', 'sentencepiece', 'tokenizers == 0.15.2',
+               'transformers == 4.37.0', 'sentencepiece', 'tokenizers == 0.15.2',
                'accelerate == 0.23.0', 'tabulate'] + cpu_torch_version
 
 SERVING_DEP = ['fschat[model_worker, webui] == 0.2.36', 'protobuf']
@@ -301,7 +301,7 @@ def setup_package():
     serving_requires += SERVING_DEP
 
     npu_requires = copy.deepcopy(all_requires)
-    cpu_transformers_version = ['transformers == 4.36.2', 'tokenizers == 0.15.2']
+    cpu_transformers_version = ['transformers == 4.37.0', 'tokenizers == 0.15.2']
     for exclude_require in cpu_transformers_version:
         npu_requires.remove(exclude_require)
     npu_requires += ["transformers==4.40.0",

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -300,6 +300,12 @@ def setup_package():
     serving_requires = ['py-cpuinfo']
     serving_requires += SERVING_DEP
 
+    npu_requires = copy.deepcopy(all_requires)
+    cpu_transformers_version = ['transformers == 4.36.2', 'tokenizers == 0.15.2']
+    for exclude_require in cpu_transformers_version:
+        npu_requires.remove(exclude_require)
+    npu_requires += ["transformers==4.40.0",
+                     "bigdl-core-npu==" + CORE_XE_VERSION]
 
     metadata = dict(
         name='ipex_llm',
@@ -323,6 +329,7 @@ def setup_package():
         },
         extras_require={"all": all_requires,
                         "xpu": xpu_requires,  # default to ipex 2.1 for linux and windows
+                        "npu": npu_requires,
                         "xpu-2-1": xpu_21_requires,
                         "serving": serving_requires,
                         "cpp": cpp_requires,


### PR DESCRIPTION
## Description

### 1. Why the change?

This PR provides `pip install ipex-llm[npu]` support for windows device.

### 2. User API changes

Previous version to run multi-processes npu example:

```
pip install ipex-llm[all]
pip install bigdl-core-npu
pip install transformers==4.40.0
```

Current version:
```
pip install ipex-llm[npu]
```

### 3. Summary of the change 


### 4. How to test?
- [x] Local test



