### PR TITLE
Support qwen2-1.5b with fused decoderlayer optimization on NPU

### DIFF
--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/README.md
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/README.md
@@ -83,7 +83,7 @@ done
 ```
 
 ## Example 2: Predict Tokens using `generate()` API using multi processes
-In the example [llama2.py](./llama2.py), we show an experimental support for a Llama2 model to predict the next N tokens using `generate()` API, with IPEX-LLM INT4 optimization and fused decoderlayer optimization on Intel NPUs.
+In the example [llama2.py](./llama2.py) and [qwen2.py](./qwen2.py), we show an experimental support for a Llama2 / Qwen2 model to predict the next N tokens using `generate()` API, with IPEX-LLM INT4 optimization and fused decoderlayer optimization on Intel NPUs.
 ### 1. Install
 #### 1.1 Installation on Windows
 We suggest using conda to manage environment:
@@ -116,7 +116,11 @@ set BIGDL_USE_NPU=1
 ### 3. Running examples
 
 ```
+# to run Llama-2-7b-chat-hf
 python  llama2.py
+
+# to run Qwen2-1.5B-Instruct
+python qwen2.py
 ```
 
 Arguments info:

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
                                          add_generation_prompt=True)
     with torch.inference_mode():
         print("finish to load")
-        for i in range(5):
+        for i in range(1):
             _input_ids = tokenizer([text], return_tensors="pt").input_ids
             print("input length:", len(_input_ids[0]))
             st = time.time()

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
@@ -67,13 +67,15 @@ if __name__ == "__main__":
 
     print("-" * 80)
     print("done")
+    messages = [{"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": args.prompt}]
+    text = tokenizer.apply_chat_template(messages,
+                                         tokenize=False,
+                                         add_generation_prompt=True)
     with torch.inference_mode():
         print("finish to load")
         for i in range(5):
-            prompt = tokenizer.apply_chat_template(args.prompt,
-                                                   tokenize=False,
-                                                   add_generation_prompt=True)
-            _input_ids = tokenizer.encode(prompt, return_tensors="pt")
+            _input_ids = tokenizer([text], return_tensors="pt").input_ids
             print("input length:", len(_input_ids[0]))
             st = time.time()
             output = model.generate(

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
@@ -1,0 +1,93 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import torch
+import time
+import argparse
+
+from ipex_llm.transformers.npu_model import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Predict Tokens using `generate()` API for npu model"
+    )
+    parser.add_argument(
+        "--repo-id-or-model-path",
+        type=str,
+        default="Qwen/Qwen2-1.5B-Instruct",
+        help="The huggingface repo id for the Qwen2 model to be downloaded"
+        ", or the path to the huggingface checkpoint folder",
+    )
+    parser.add_argument('--prompt', type=str, default="What is AI?",
+                        help='Prompt to infer')
+    parser.add_argument("--n-predict", type=int, default=32, help="Max tokens to predict")
+    parser.add_argument("--max-output-len", type=int, default=1024)
+    parser.add_argument("--max-prompt-len", type=int, default=512)
+    parser.add_argument("--disable-transpose-value-cache", action="store_true", default=False)
+    parser.add_argument("--intra-pp", type=int, default=2)
+    parser.add_argument("--inter-pp", type=int, default=1)
+
+    args = parser.parse_args()
+    model_path = args.repo_id_or_model_path
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        torch_dtype=torch.float16,
+        trust_remote_code=True,
+        attn_implementation="eager",
+        load_in_low_bit="sym_int4",
+        enable_mp=True,
+        max_output_len=args.max_output_len,
+        max_prompt_len=args.max_prompt_len,
+        intra_pp=args.intra_pp,
+        inter_pp=args.inter_pp,
+        transpose_value_cache=not args.disable_transpose_value_cache,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+
+    print("-" * 80)
+    print("done")
+    with torch.inference_mode():
+        print("finish to load")
+        for i in range(5):
+            prompt = tokenizer.apply_chat_template(args.prompt,
+                                                   tokenize=False,
+                                                   add_generation_prompt=True)
+            _input_ids = tokenizer.encode(prompt, return_tensors="pt")
+            print("input length:", len(_input_ids[0]))
+            st = time.time()
+            output = model.generate(
+                _input_ids, num_beams=1, do_sample=False, max_new_tokens=args.n_predict
+            )
+            end = time.time()
+            print(f"Inference time: {end-st} s")
+            input_str = tokenizer.decode(_input_ids[0], skip_special_tokens=False)
+            print("-" * 20, "Input", "-" * 20)
+            print(input_str)
+            output_str = tokenizer.decode(output[0], skip_special_tokens=False)
+            print("-" * 20, "Output", "-" * 20)
+            print(output_str)
+
+    print("-" * 80)
+    print("done")
+    print("success shut down")

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/qwen2.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
                                          add_generation_prompt=True)
     with torch.inference_mode():
         print("finish to load")
-        for i in range(1):
+        for i in range(3):
             _input_ids = tokenizer([text], return_tensors="pt").input_ids
             print("input length:", len(_input_ids[0]))
             st = time.time()

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -54,3 +54,26 @@ def optimize_llm(
             prefill_runner=prefill_runner, decode_runner=decode_runner
         )
         convert_forward(model, LlamaModel, llama_model_forward)
+    elif model.config.model_type == "qwen2" and model.config.intermediate_size == 8960:
+        # for qwen2-1.5B
+        from ipex_llm.transformers.npu_models.qwen2_mp import gen_qwen2_fused_model_forward
+        from ipex_llm.transformers.npu_models.qwen2_mp import DecodeRunner, PrefillRunner
+        from transformers.models.qwen2.modeling_qwen2 import Qwen2Model
+
+        decode_runner = DecodeRunner(
+            model,
+            max_seq_len=max_output_len,
+            inter_pp=inter_pp,
+            intra_pp=intra_pp,
+            transpose_value_cache=transpose_value_cache,
+        )
+        prefill_runner = PrefillRunner(
+            model,
+            max_output_len=max_output_len,
+            max_prompt_len=max_prompt_len,
+            transpose_value_cache=transpose_value_cache,
+        )
+        qwen2_model_forward = gen_qwen2_fused_model_forward(
+            prefill_runner=prefill_runner, decode_runner=decode_runner
+        )
+        convert_forward(model, Qwen2Model, qwen2_model_forward)

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -201,7 +201,8 @@ class LLMBaseNNFactory(NNFactory):
                                       n_rep=num_key_value_groups,
                                       num_key_value_heads=num_key_value_heads,
                                       kv_seq_len=kv_seq_len,
-                                      head_dim=head_dim,)
+                                      head_dim=head_dim,
+                                      transpose=self.transpose_value)
         attn_weight = self.matmul(query_states, key_states, False, True) / (
             math.sqrt(head_dim)
         )

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -118,7 +118,10 @@ class LLMBaseNNFactory(NNFactory):
                   num_heads,
                   num_key_value_heads,
                   head_dim,
-                  seq_len):
+                  seq_len,
+                  q_bias=None,
+                  k_bias=None,
+                  v_bias=None):
         hidden_size = num_heads * head_dim
         num_key_value_groups = num_heads // num_key_value_heads
         query_states = self.linear(
@@ -128,6 +131,8 @@ class LLMBaseNNFactory(NNFactory):
             bias=False,
             wt_dtype=self.dtype,
         )
+        if q_bias is not None:
+            query_states = query_states + q_bias
         key_states = self.linear(
             hidden_states,
             num_key_value_heads * head_dim,
@@ -135,6 +140,8 @@ class LLMBaseNNFactory(NNFactory):
             bias=False,
             wt_dtype=self.dtype,
         )
+        if k_bias is not None:
+            key_states = key_states + k_bias
         value_states = self.linear(
             hidden_states,
             num_key_value_heads * head_dim,
@@ -142,6 +149,8 @@ class LLMBaseNNFactory(NNFactory):
             bias=False,
             wt_dtype=self.dtype,
         )
+        if v_bias is not None:
+            value_states = value_states + v_bias
 
         query_states = self.reshape(
             query_states, [1, seq_len, num_heads, head_dim]

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -41,7 +41,7 @@ from ipex_llm.transformers.npu_models.mp_models_base import run_model
 from ipex_llm.transformers.npu_models.mp_models_base import LLMBaseNNFactory
 
 
-class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
+class LowBitQwenMultiDecoderlayer(LLMBaseNNFactory):
     def __init__(
         self,
         # batch_size: int,
@@ -56,6 +56,9 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
         cached_sin,
         input_layernorm_weights=None,
         post_attn_layernorm_weights=None,
+        q_biases=None,
+        k_biases=None,
+        v_biases=None,
         mode: str = "prefill",
         dtype: np.dtype = np.int8,
         max_seq_len: int = 1024,
@@ -153,6 +156,21 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
             input_layernorm_weights = [self.constant(w) for w in input_layernorm_weights]
             post_attn_layernorm_weights = [self.constant(w) for w in post_attn_layernorm_weights]
 
+        if q_biases is None:
+            assert k_biases is None
+            assert v_biases is None
+            q_biases = []
+            k_biases = []
+            v_biases = []
+            for i in range(num_layers):
+                q_biases.append(self.parameter((self.num_heads * self.head_dim,)))
+                k_biases.append(self.parameter((self.num_key_value_heads * self.head_dim,)))
+                v_biases.append(self.parameter((self.num_key_value_heads * self.head_dim,)))
+        else:
+            q_biases = [self.constant(w) for w in q_biases]
+            k_biases = [self.constant(w) for w in k_biases]
+            v_biases = [self.constant(w) for w in v_biases]
+
         hidden_states = input
 
         curr_key_values = []
@@ -163,6 +181,9 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
                 position_ids=position_ids,
                 input_layernorm_weight=input_layernorm_weights[i],
                 post_attention_layernorm_weight=post_attn_layernorm_weights[i],
+                q_bias=q_biases[i],
+                k_bias=k_biases[i],
+                v_bias=v_biases[i],
                 past_key=past_keys[i],
                 past_value=past_values[i],
             )
@@ -185,6 +206,9 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
         position_ids,
         input_layernorm_weight,
         post_attention_layernorm_weight,
+        q_bias,
+        k_bias,
+        v_bias,
         past_key=None,
         past_value=None,
     ):
@@ -205,6 +229,9 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
             num_key_value_heads=self.num_key_value_heads,
             head_dim=self.head_dim,
             seq_len=self.seq_len,
+            q_bias=q_bias,
+            k_bias=k_bias,
+            v_bias=v_bias,
         )
         hidden_states = self.eltwise_add(residual, attn_output)
         residual = hidden_states
@@ -216,13 +243,16 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
         return hidden_states, new_key_states, new_value_states
 
 
-class FusedLlamaLowBitMultiDecoderlayer(torch.nn.Module):
+class FusedQwenLowBitMultiDecoderlayer(torch.nn.Module):
 
     def __init__(
         self,
         parameters: List[Tuple[torch.Tensor]],
         input_laynorm_weights: List[torch.Tensor],
         post_attn_layernorm_weights: List[torch.Tensor],
+        q_biases: List[torch.Tensor],
+        k_biases: List[torch.Tensor],
+        v_biases: List[torch.Tensor],
         layer_indexes: List[int],
         intra_stages: int,
         cached_cos: torch.Tensor,
@@ -271,10 +301,13 @@ class FusedLlamaLowBitMultiDecoderlayer(torch.nn.Module):
             start, end = self.layer_ranges[i]
             lm_0 = input_laynorm_weights[start:end]
             lm_1 = post_attn_layernorm_weights[start:end]
-            decoder = LowBitLlamaMultiDecoderlayer(
+            decoder = LowBitQwenMultiDecoderlayer(
                 [1, 1, num_heads * head_dim],
                 input_layernorm_weights=lm_0,
                 post_attn_layernorm_weights=lm_1,
+                q_biases=q_biases[start:end],
+                k_biases=k_biases[start:end],
+                v_biases=v_biases[start:end],
                 cached_cos=cached_cos,
                 cached_sin=cached_sin,
                 num_heads=num_heads,
@@ -315,7 +348,7 @@ class FusedLlamaLowBitMultiDecoderlayer(torch.nn.Module):
             start, end = self.layer_ranges[i]
             self.backend_decoders[i].update_cache(past_key_value, self.layer_indexes[start:end])
 
-        hidden_states, new_keys, new_values = LowBitLlamaMultiDecoderlayer.run_decoders(
+        hidden_states, new_keys, new_values = LowBitQwenMultiDecoderlayer.run_decoders(
             inputs,
             decoders=self.backend_decoders)
 
@@ -326,14 +359,13 @@ class FusedLlamaLowBitMultiDecoderlayer(torch.nn.Module):
         outputs += (past_key_value, new_keys, new_values)
         return outputs
 
-    def post_forward(self, past_key_value, new_keys, new_values, cache_position):
+    def post_forward(self, past_key_value, new_keys, new_values):
         key_value_states = []
         for i in range(self.intra_stages):
             for j in range(1, len(self.backend_decoders[i].torch_out)):
                 key_value_states.append(self.backend_decoders[i].torch_out[j])
 
         cache_kwargs = {
-            "cache_position": cache_position,
             "max_seq_len": self.max_seq_len,
             "transpose": self.transpose_value,
         }
@@ -349,9 +381,7 @@ class FusedLlamaLowBitMultiDecoderlayer(torch.nn.Module):
             self.backend_decoders[i].load_cache_async()
 
 
-class FusedLlamaLowBitDecoderlayer(torch.nn.Module):
-    """LLAMA MLP operation NPU backend."""
-
+class FusedQwenLowBitDecoderlayer(torch.nn.Module):
     def __init__(
         self,
         parameters: List[torch.Tensor],
@@ -359,6 +389,9 @@ class FusedLlamaLowBitDecoderlayer(torch.nn.Module):
         cached_sin,
         layer_norm_0,
         layer_norm_1,
+        q_bias,
+        k_bias,
+        v_bias,
         num_heads: int,
         num_key_value_heads: int,
         layer_idx: int,
@@ -380,7 +413,7 @@ class FusedLlamaLowBitDecoderlayer(torch.nn.Module):
             np_dtype = np.float16
 
         self.backend_cls_prefill = partial(
-            LowBitLlamaMultiDecoderlayer,
+            LowBitQwenMultiDecoderlayer,
             num_heads=num_heads,
             num_key_value_heads=num_key_value_heads,
             num_layers=1,
@@ -397,6 +430,9 @@ class FusedLlamaLowBitDecoderlayer(torch.nn.Module):
         )
         self.layer_norm_0 = layer_norm_0
         self.layer_norm_1 = layer_norm_1
+        self.q_bias = q_bias
+        self.k_bias = k_bias
+        self.v_bias = v_bias
 
     def forward(
         self,
@@ -427,7 +463,6 @@ class FusedLlamaLowBitDecoderlayer(torch.nn.Module):
             inputs, self.op_parameters, backend_cls, self.op_id, replica=2
         )
         cache_kwargs = {
-            "cache_position": cache_position,
             "max_seq_len": self.max_seq_len,
             "transpose": self.transpose_value,
         }
@@ -475,6 +510,9 @@ def run_decode(
     layer_weights = []
     input_layer_norm_weights = []
     post_attn_layernorm_weights = []
+    q_biases = []
+    k_biases = []
+    v_biases = []
     layer_indexs = range(layer_start, layer_end)
     for layer_idx in layer_indexs:
         curr_layer = model.model.layers[layer_idx]
@@ -499,11 +537,17 @@ def run_decode(
         layer_weights.extend(weights)
         input_layer_norm_weights.append(layer_norm_0)
         post_attn_layernorm_weights.append(layer_norm_1)
+        q_biases.append(attn_layer.q_proj.bias.to(torch.float16))
+        k_biases.append(attn_layer.k_proj.bias.to(torch.float16))
+        v_biases.append(attn_layer.v_proj.bias.to(torch.float16))
 
-    multi_decoder = FusedLlamaLowBitMultiDecoderlayer(
+    multi_decoder = FusedQwenLowBitMultiDecoderlayer(
         parameters=layer_weights,
         input_laynorm_weights=input_layer_norm_weights,
         post_attn_layernorm_weights=post_attn_layernorm_weights,
+        q_biases=q_biases,
+        k_biases=k_biases,
+        v_biases=v_biases,
         layer_indexes=layer_indexs,
         intra_stages=intra_stages,
         cached_cos=cached_cos,
@@ -536,16 +580,26 @@ def run_decode(
                 t0 = time.perf_counter()
                 past_seen_tokens = past_key_values.get_seq_length()
                 attention_mask = torch.ones([1, past_seen_tokens + 1], dtype=torch.int64)
-                cache_position = torch.arange(
-                    past_seen_tokens, past_seen_tokens + 1, device=hidden_states.device
+                position_ids = torch.arange(
+                    past_seen_tokens,
+                    1 + past_seen_tokens,
+                    dtype=torch.long,
+                    device=hidden_states.device,
                 )
+                position_ids = position_ids.unsqueeze(0).view(-1, 1)
 
-                position_ids = position_ids = cache_position.unsqueeze(0)
-                causal_mask = model.model._update_causal_mask(
-                    attention_mask, hidden_states, cache_position, past_seen_tokens
+                from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
+
+                causal_mask = _prepare_4d_causal_attention_mask(
+                    attention_mask,
+                    (hidden_states.shape[0], 1),
+                    hidden_states,
+                    past_seen_tokens,
+                    sliding_window=model.model.config.sliding_window,
                 )
                 pad_len = multi_decoder.max_seq_len + 1 - causal_mask.size(-1)
 
+                causal_mask[:, :, :, -1] = torch.finfo(torch.float16).min
                 pad_mask = (0, pad_len)
                 padded_causal_mask = F.pad(
                     causal_mask.to(torch.float16), pad_mask, value=torch.finfo(torch.float16).min
@@ -560,7 +614,6 @@ def run_decode(
                     past_key_value=past_key_values,
                     output_attentions=False,
                     use_cache=True,
-                    cache_position=cache_position,
                 )
                 t2 = time.perf_counter()
                 hidden_states = layer_outputs[0]
@@ -570,7 +623,7 @@ def run_decode(
                 past_key_values = layer_outputs[1]
                 new_keys = layer_outputs[2]
                 new_values = layer_outputs[3]
-                multi_decoder.post_forward(past_key_values, new_keys, new_values, cache_position)
+                multi_decoder.post_forward(past_key_values, new_keys, new_values)
 
 
 class DecodeRunner:
@@ -637,7 +690,6 @@ class DecodeRunner:
         past_key_value: Optional[Cache] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_position: Optional[torch.LongTensor] = None,
         **kwargs,
     ):
         t0 = time.perf_counter()
@@ -707,7 +759,7 @@ def run_prefill(
         layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
         layer_norm_1 = curr_layer.post_attention_layernorm.weight.to(torch.float16)
 
-        new_decoderlayer = FusedLlamaLowBitDecoderlayer(
+        new_decoderlayer = FusedQwenLowBitDecoderlayer(
             weights,
             num_heads=num_heads,
             num_key_value_heads=num_key_value_heads,
@@ -715,6 +767,9 @@ def run_prefill(
             cached_sin=cached_sin,
             layer_norm_0=layer_norm_0,
             layer_norm_1=layer_norm_1,
+            q_bias=attn_layer.q_proj.bias.to(torch.float16),
+            k_bias=attn_layer.k_proj.bias.to(torch.float16),
+            v_bias=attn_layer.v_proj.bias.to(torch.float16),
             layer_idx=layer_idx,
             rms_norm_eps=rms_norm_eps,
             intermediate_size=intermediate_size,
@@ -747,7 +802,6 @@ def run_prefill(
                     past_key_value=past_key_values,
                     output_attentions=False,
                     use_cache=True,
-                    cache_position=cache_position,
                 )
 
                 hidden_states = layer_outputs[0]
@@ -791,7 +845,6 @@ class PrefillRunner:
         past_key_value: Optional[Cache] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_position: Optional[torch.LongTensor] = None,
         **kwargs,
     ):
         seq_len = hidden_states.size(1)
@@ -811,7 +864,7 @@ class PrefillRunner:
             value=torch.finfo(torch.float16).min,
         )
 
-        args = (hidden_states, position_ids, attention_mask, past_key_value, cache_position)
+        args = (hidden_states, position_ids, attention_mask, past_key_value)
         self.prefill_input_queue.put(args)
         hidden_states, past_key_value = self.prefill_result_queue.get()
         past_key_value.shrink(seq_len, self.transpose_value_cache)
@@ -828,9 +881,9 @@ class PrefillRunner:
         self.shutdown()
 
 
-def gen_llama_fused_model_forward(prefill_runner, decode_runner):
+def gen_qwen2_fused_model_forward(prefill_runner, decode_runner):
 
-    def llama_fused_model_forward(
+    def qwen2_fused_model_forward(
         self,
         input_ids: torch.LongTensor = None,
         attention_mask: Optional[torch.Tensor] = None,
@@ -841,9 +894,7 @@ def gen_llama_fused_model_forward(prefill_runner, decode_runner):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
-        t0 = time.perf_counter()
         output_attentions = (
             output_attentions if output_attentions is not None else self.config.output_attentions
         )
@@ -853,43 +904,58 @@ def gen_llama_fused_model_forward(prefill_runner, decode_runner):
             else self.config.output_hidden_states
         )
         use_cache = use_cache if use_cache is not None else self.config.use_cache
+
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        if (input_ids is None) ^ (inputs_embeds is not None):
-            msg = (
-                "You cannot specify both input_ids and inputs_embeds at the same time,"
-                " and must specify either one"
+        # retrieve input_ids and inputs_embeds
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time"
             )
-            invalidInputError(False, msg)
+        elif input_ids is not None:
+            batch_size, seq_length = input_ids.shape
+        elif inputs_embeds is not None:
+            batch_size, seq_length, _ = inputs_embeds.shape
+        else:
+            raise ValueError(
+                "You have to specify either decoder_input_ids or decoder_inputs_embeds"
+            )
 
-        if self.gradient_checkpointing and self.training and use_cache:
-            use_cache = False
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                use_cache = False
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        past_seen_tokens = 0
+        past_key_values_length = 0
 
-        # ipex-llm changes start
         from ipex_llm.transformers.npu_models.kv import DynamicFusedNormalCache
 
         if use_cache and not isinstance(past_key_values, DynamicFusedNormalCache):
             past_key_values = DynamicFusedNormalCache.from_legacy_cache(past_key_values)
-            past_seen_tokens = past_key_values.get_seq_length()
-
-        if cache_position is None:
-            cache_position = torch.arange(
-                past_seen_tokens,
-                past_seen_tokens + inputs_embeds.shape[1],
-                device=inputs_embeds.device,
-            )
-        # ipex-llm changes end
+            past_key_values_length = past_key_values.get_seq_length()
 
         if position_ids is None:
-            position_ids = cache_position.unsqueeze(0)
+            device = input_ids.device if input_ids is not None else inputs_embeds.device
+            position_ids = torch.arange(
+                past_key_values_length,
+                seq_length + past_key_values_length,
+                dtype=torch.long,
+                device=device,
+            )
+            position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
+        else:
+            position_ids = position_ids.view(-1, seq_length).long()
 
-        causal_mask = self._update_causal_mask(
-            attention_mask, inputs_embeds, cache_position, past_seen_tokens
+        from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
+
+        attention_mask = _prepare_4d_causal_attention_mask(
+            attention_mask,
+            (batch_size, seq_length),
+            inputs_embeds,
+            past_key_values_length,
+            sliding_window=self.config.sliding_window,
         )
 
         # embed positions
@@ -900,20 +966,17 @@ def gen_llama_fused_model_forward(prefill_runner, decode_runner):
         all_self_attns = () if output_attentions else None
         next_decoder_cache = None
 
-        seq_len = hidden_states.size(1)
-
-        if seq_len == 1:
+        if seq_length == 1:
             layers_runner = decode_runner
         else:
             layers_runner = prefill_runner
         layer_outputs = layers_runner.forward(
             hidden_states,
-            attention_mask=causal_mask,
+            attention_mask=attention_mask,
             position_ids=position_ids,
             past_key_value=past_key_values,
             output_attentions=output_attentions,
             use_cache=use_cache,
-            cache_position=cache_position,
         )
         hidden_states = layer_outputs[0]
 
@@ -925,17 +988,14 @@ def gen_llama_fused_model_forward(prefill_runner, decode_runner):
         if output_hidden_states:
             all_hidden_states += (hidden_states,)
 
-        # ipex-llm changes start
         next_cache = next_decoder_cache if use_cache else None
-        # ipex-llm changes end
         if not return_dict:
             return tuple(
                 v
                 for v in [hidden_states, next_cache, all_hidden_states, all_self_attns]
                 if v is not None
             )
-        t1 = time.perf_counter()
-        # print("fused model forward time: ", t1 - t0)
+
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=next_cache,
@@ -943,4 +1003,4 @@ def gen_llama_fused_model_forward(prefill_runner, decode_runner):
             attentions=all_self_attns,
         )
 
-    return llama_fused_model_forward
+    return qwen2_fused_model_forward


### PR DESCRIPTION
## Description

Add qwen2-1.5B NPU support with fused decoderlayer and multi process optimization.

### 3. Summary of the change 

- common changes: add bias parameter for LLMBaseNNFactory.attention, fix small bug of repeat_kv
- qwen2 specific: add related convert, add decoderrunner / prefillrunner / fuseddecoder etc, provide example script
- llama2 specific: remove unused import

### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.  
https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/10487861709
- [x] Application test (verified on MTL and LNL, https://github.com/analytics-zoo/nano/issues/1576#issuecomment-2300519193)
