### PR TITLE
Disable lm_head opt for baichuan2-13b

### DIFF
--- a/python/llm/src/ipex_llm/transformers/convert.py
+++ b/python/llm/src/ipex_llm/transformers/convert.py
@@ -405,9 +405,11 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
             optimize_lm_head = (
                 is_lm_head(name, model_config, out_features)
                 and (
-                    (not os.environ.get("IPEX_LLM_LAST_LM_HEAD", None) == "0")
-                    or os.environ.get("IPEX_LLM_LOW_MEM", "0") == "1"
-                    and getattr(model_config, "model_type", "") in ["gptj", "llama", "qwen2"]
+                    not os.environ.get("IPEX_LLM_LAST_LM_HEAD", None) == "0"
+                )
+                and (
+                    not (getattr(model_config, "model_type", "") == "baichuan" and
+                         model.config.hidden_size == 5120)  # except baichuan2-13B
                 )
             )
             with init_empty_weights():


### PR DESCRIPTION
## Description

Baichuan2-13b memory keeps increasing when using lm_head optimization.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
