### PR TITLE
added accelerate upgrade in ollama UI quickstart

### DIFF
--- a/docs/mddocs/Quickstart/open_webui_with_ollama_quickstart.md
+++ b/docs/mddocs/Quickstart/open_webui_with_ollama_quickstart.md
@@ -75,6 +75,7 @@ You may run below commands to install Open WebUI dependencies:
   # Install Dependencies
   cd ./backend
   pip install -r requirements.txt -U
+  pip install --pre --upgrade accelerate
   ```
 
 - For **Windows users**:
@@ -90,6 +91,7 @@ You may run below commands to install Open WebUI dependencies:
   :: Install Dependencies
   cd .\backend
   pip install -r requirements.txt -U
+  pip install --pre --upgrade accelerate
   ```
 
 ### 3. Start the Open-WebUI 


### PR DESCRIPTION
accelerate version specified in `bigdl-core-cpp` is fallen behind and will result in incompatibility with transformers when running `open-webui` for ollama, therefore requires an upgrade before running `start_windows.bat`