### PR TITLE
Initial NPU support for MiniCPM-V-2_6

### DIFF
--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
@@ -45,11 +45,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     model_path = args.repo_id_or_model_path
     image_path = args.image_url_or_path
-    
-    # Load model in 4 bit,
-    # which convert the relevant layers in the model into INT4 format
-    # When running LLMs on Intel iGPUs for Windows users, we recommend setting `cpu_embedding=True` in the from_pretrained function.
-    # This will allow the memory-intensive embedding layer to utilize the CPU instead of iGPU.
+
     model = AutoModel.from_pretrained(model_path, 
                                       torch_dtype=torch.float32,
                                       trust_remote_code=True,
@@ -78,13 +74,14 @@ if __name__ == '__main__':
     # here the prompt tuning refers to https://huggingface.co/openbmb/MiniCPM-V-2_6/blob/main/README.md
     msg = [{'role': 'user', 'content': args.prompt}]
     st = time.time()
-    res = model.chat(
-     image=image,
-     msgs=msg,
-     context=None,
-     tokenizer=tokenizer,
-     sampling=True,
-    )
+    with torch.inference_mode():
+        res = model.chat(
+            image=image,
+            msgs=msg,
+            context=None,
+            tokenizer=tokenizer,
+            sampling=True,
+        )
     end = time.time()
     print(f'Inference time: {end-st} s')
     print('-'*20, 'Input', '-'*20)

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
@@ -1,0 +1,187 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from typing import List, Tuple, Optional, Union
+import math
+import timm
+import torch
+import torch.nn.functional as F
+
+# patched: `timm` has limited support for XPU backend, so we need to use CPU as a workaround
+def resample_abs_pos_embed(
+        posemb: torch.Tensor,
+        new_size: List[int],
+        old_size: Optional[List[int]] = None,
+        num_prefix_tokens: int = 1,
+        interpolation: str = 'bicubic',
+        antialias: bool = True,
+        verbose: bool = False,
+):
+    # sort out sizes, assume square if old size not provided
+    num_pos_tokens = posemb.shape[1]
+    num_new_tokens = new_size[0] * new_size[1] + num_prefix_tokens
+    if num_new_tokens == num_pos_tokens and new_size[0] == new_size[1]:
+        return posemb
+
+    if old_size is None:
+        hw = int(math.sqrt(num_pos_tokens - num_prefix_tokens))
+        old_size = hw, hw
+
+    if num_prefix_tokens:
+        posemb_prefix, posemb = posemb[:, :num_prefix_tokens], posemb[:, num_prefix_tokens:]
+    else:
+        posemb_prefix, posemb = None, posemb
+
+    # do the interpolation
+    embed_dim = posemb.shape[-1]
+    orig_dtype = posemb.dtype
+    posemb = posemb.float()  # interpolate needs float32
+    posemb = posemb.reshape(1, old_size[0], old_size[1], -1).permute(0, 3, 1, 2)
+    #posemb = F.interpolate(posemb, size=new_size, mode=interpolation, antialias=antialias)
+    posemb = F.interpolate(posemb.to("cpu"), size=new_size, mode=interpolation, antialias=antialias).to(posemb.device)
+    posemb = posemb.permute(0, 2, 3, 1).reshape(1, -1, embed_dim)
+    posemb = posemb.to(orig_dtype)
+
+    # add back extra (class, etc) prefix tokens
+    if posemb_prefix is not None:
+        posemb = torch.cat([posemb_prefix, posemb], dim=1)
+
+    if not torch.jit.is_scripting() and verbose:
+        _logger.info(f'Resized position embedding: {old_size} to {new_size}.')
+
+    return posemb
+
+
+def _pos_embed(self, x: torch.Tensor) -> torch.Tensor:
+    if self.pos_embed is None:
+        return x.view(x.shape[0], -1, x.shape[-1])
+
+    if self.dynamic_img_size:
+        B, H, W, C = x.shape
+        pos_embed = resample_abs_pos_embed(
+            self.pos_embed,
+            (H, W),
+            num_prefix_tokens=0 if self.no_embed_class else self.num_prefix_tokens,
+        )
+        x = x.view(B, -1, C)
+    else:
+        pos_embed = self.pos_embed
+
+    to_cat = []
+    if self.cls_token is not None:
+        to_cat.append(self.cls_token.expand(x.shape[0], -1, -1))
+    if self.reg_token is not None:
+        to_cat.append(self.reg_token.expand(x.shape[0], -1, -1))
+
+    if self.no_embed_class:
+        # deit-3, updated JAX (big vision)
+        # position embedding does not overlap with class token, add then concat
+        x = x + pos_embed
+        if to_cat:
+            x = torch.cat(to_cat + [x], dim=1)
+    else:
+        # original timm, JAX, and deit vit impl
+        # pos_embed has entry for class token, concat then add
+        if to_cat:
+            x = torch.cat(to_cat + [x], dim=1)
+        x = x + pos_embed
+
+    return self.pos_drop(x)
+
+
+setattr(timm.models.VisionTransformer, "_pos_embed", _pos_embed)
+
+
+import os
+import time
+import argparse
+import requests
+from PIL import Image
+from ipex_llm.transformers.npu_model import AutoModel
+from transformers import AutoTokenizer
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for openbmb/MiniCPM-V-2_6 model')
+    parser.add_argument('--repo-id-or-model-path', type=str, default="D:\SuperBuilder\MiniCPM-V-2_6",
+                        help='The huggingface repo id for the openbmb/MiniCPM-V-2_6 model to be downloaded'
+                             ', or the path to the huggingface checkpoint folder')
+    parser.add_argument('--image-url-or-path', type=str,
+                        default='http://farm6.staticflickr.com/5268/5602445367_3504763978_z.jpg',
+                        help='The URL or path to the image to infer')
+    parser.add_argument('--prompt', type=str, default="What is in this image?",
+                        help='Prompt to infer')
+    parser.add_argument("--n-predict", type=int, default=32, help="Max tokens to predict")
+    parser.add_argument("--max-output-len", type=int, default=1024)
+    parser.add_argument("--max-prompt-len", type=int, default=960)
+    parser.add_argument("--disable-transpose-value-cache", action="store_true", default=False)
+    parser.add_argument("--intra-pp", type=int, default=2)
+    parser.add_argument("--inter-pp", type=int, default=2)
+
+    args = parser.parse_args()
+    model_path = args.repo_id_or_model_path
+    image_path = args.image_url_or_path
+    
+    # Load model in 4 bit,
+    # which convert the relevant layers in the model into INT4 format
+    # When running LLMs on Intel iGPUs for Windows users, we recommend setting `cpu_embedding=True` in the from_pretrained function.
+    # This will allow the memory-intensive embedding layer to utilize the CPU instead of iGPU.
+    model = AutoModel.from_pretrained(model_path, 
+                                      torch_dtype=torch.float32,
+                                      trust_remote_code=True,
+                                      attn_implementation="eager",
+                                      load_in_low_bit="sym_int4",
+                                      optimize_model=True,
+                                      max_output_len=args.max_output_len,
+                                      max_prompt_len=args.max_prompt_len,
+                                      intra_pp=args.intra_pp,
+                                      inter_pp=args.inter_pp,
+                                      transpose_value_cache=not args.disable_transpose_value_cache,
+                                      modules_to_not_convert=['vpm', 'resampler']
+                                     )
+    print(model)
+    tokenizer = AutoTokenizer.from_pretrained(model_path,
+                                              trust_remote_code=True)
+    model.eval()
+
+    query = args.prompt
+    if os.path.exists(image_path):
+       image = Image.open(image_path).convert('RGB')
+    else:
+       image = Image.open(requests.get(image_path, stream=True).raw).convert('RGB')
+
+    # Generate predicted tokens
+    # here the prompt tuning refers to https://huggingface.co/openbmb/MiniCPM-V-2_6/blob/main/README.md
+    # msgs = [{'role': 'user', 'content': [image, args.prompt]}]
+    msg = [{'role': 'user', 'content': args.prompt}]
+    st = time.time()
+    res = model.chat(
+     image=image,
+     msgs=msg,
+     context=None,
+     tokenizer=tokenizer,
+     sampling=True,
+    )
+    end = time.time()
+    print(f'Inference time: {end-st} s')
+    print('-'*20, 'Input', '-'*20)
+    print(image_path)
+    print('-'*20, 'Prompt', '-'*20)
+    print(args.prompt)
+    output_str = res
+    print('-'*20, 'Output', '-'*20)
+    print(output_str)

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
@@ -26,8 +26,8 @@ from transformers import AutoTokenizer
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for openbmb/MiniCPM-V-2_6 model')
-    parser.add_argument('--repo-id-or-model-path', type=str, default="openbmb/MiniCPM-V-2_6",
+    parser = argparse.ArgumentParser(description='Predict Tokens using `chat()` API for openbmb/MiniCPM-V-2_6 model')
+    parser.add_argument('--repo-id-or-model-path', type=str, default="openbmb/MiniCPM-V-2_6 model",
                         help='The huggingface repo id for the openbmb/MiniCPM-V-2_6 model to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
     parser.add_argument('--image-url-or-path', type=str,
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     parser.add_argument("--max-prompt-len", type=int, default=960)
     parser.add_argument("--disable-transpose-value-cache", action="store_true", default=False)
     parser.add_argument("--intra-pp", type=int, default=2)
-    parser.add_argument("--inter-pp", type=int, default=4)
+    parser.add_argument("--inter-pp", type=int, default=2)
 
     args = parser.parse_args()
     model_path = args.repo_id_or_model_path
@@ -59,7 +59,6 @@ if __name__ == '__main__':
                                       transpose_value_cache=not args.disable_transpose_value_cache,
                                       modules_to_not_convert=['vpm', 'resampler']
                                      )
-    print(model)
     tokenizer = AutoTokenizer.from_pretrained(model_path,
                                               trust_remote_code=True)
     model.eval()

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
@@ -27,7 +27,7 @@ from transformers import AutoTokenizer
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `chat()` API for openbmb/MiniCPM-V-2_6 model')
-    parser.add_argument('--repo-id-or-model-path', type=str, default="openbmb/MiniCPM-V-2_6 model",
+    parser.add_argument('--repo-id-or-model-path', type=str, default="openbmb/MiniCPM-V-2_6",
                         help='The huggingface repo id for the openbmb/MiniCPM-V-2_6 model to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
     parser.add_argument('--image-url-or-path', type=str,

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     parser.add_argument("--max-prompt-len", type=int, default=960)
     parser.add_argument("--disable-transpose-value-cache", action="store_true", default=False)
     parser.add_argument("--intra-pp", type=int, default=2)
-    parser.add_argument("--inter-pp", type=int, default=2)
+    parser.add_argument("--inter-pp", type=int, default=4)
 
     args = parser.parse_args()
     model_path = args.repo_id_or_model_path

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/Multimodal/minicpm_v_2_6.py
@@ -27,7 +27,7 @@ from transformers import AutoTokenizer
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for openbmb/MiniCPM-V-2_6 model')
-    parser.add_argument('--repo-id-or-model-path', type=str, default="D:\SuperBuilder\MiniCPM-V-2_6",
+    parser.add_argument('--repo-id-or-model-path', type=str, default="openbmb/MiniCPM-V-2_6",
                         help='The huggingface repo id for the openbmb/MiniCPM-V-2_6 model to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
     parser.add_argument('--image-url-or-path', type=str,

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -113,7 +113,6 @@ class _BaseAutoModelClass:
         ignore_argument(kwargs, "cpu_embedding")
         ignore_argument(kwargs, "embedding_qtype")
         ignore_argument(kwargs, "enable_mp")
-        # ignore_argument(kwargs, "modules_to_not_convert")
         ignore_argument(kwargs, "quantization_config")
         ignore_argument(kwargs, "speculative")
         ignore_argument(kwargs, "pipeline_parallel_stages")
@@ -124,7 +123,6 @@ class _BaseAutoModelClass:
         intra_pp = kwargs.pop("intra_pp", None)
         transpose_value_cache = kwargs.pop("transpose_value_cache", True)
         modules_to_not_convert = kwargs.pop("modules_to_not_convert", [])
-        print("modules_to_not_convert is !!!  ", modules_to_not_convert)
 
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
@@ -176,8 +174,6 @@ class _BaseAutoModelClass:
             logger.info(f"Finish to convert model")
             model.config.update({"bigdl_transformers_low_bit": qtype})
             model.share_memory()
-
-            print("[debug] model type!!! ", llm.config.model_type)
 
             optimize_llm(
                 llm,

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -157,19 +157,10 @@ class _BaseAutoModelClass:
             else:
                 llm = model
 
-            if model.config.model_type == "minicpmv":
-                # MiniCPM-V
-                if model.config.hidden_size == 3584 and model.config.vocab_size == 151666:
-                    # MiniCPM-V 2.6
-                    model.llm.config.model_type = "qwen2"
-
             with torch.no_grad():
                 optimize_llm_pre(llm, qtype)
                 cls.load_convert(qtype, model, "cpu", modules_to_not_convert, *args, **kwargs)
-                if hasattr(model, "llm"):
-                    create_npu_kernels(model.llm)
-                else:
-                    create_npu_kernels(model)
+                create_npu_kernels(llm)
             model = model.eval()
             logger.info(f"Finish to convert model")
             model.config.update({"bigdl_transformers_low_bit": qtype})

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -156,7 +156,7 @@ class _BaseAutoModelClass:
                 llm = model.llm
             else:
                 llm = model
-            
+
             if model.config.model_type == "minicpmv":
                 # MiniCPM-V
                 if model.config.hidden_size == 3584 and model.config.vocab_size == 151666:

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -158,7 +158,7 @@ class _BaseAutoModelClass:
                 llm = model
 
             with torch.no_grad():
-                optimize_llm_pre(llm, qtype)
+                optimize_llm_pre(model, qtype)
                 cls.load_convert(qtype, model, "cpu", modules_to_not_convert, *args, **kwargs)
                 create_npu_kernels(llm)
             model = model.eval()

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -113,7 +113,7 @@ class _BaseAutoModelClass:
         ignore_argument(kwargs, "cpu_embedding")
         ignore_argument(kwargs, "embedding_qtype")
         ignore_argument(kwargs, "enable_mp")
-        ignore_argument(kwargs, "modules_to_not_convert")
+        # ignore_argument(kwargs, "modules_to_not_convert")
         ignore_argument(kwargs, "quantization_config")
         ignore_argument(kwargs, "speculative")
         ignore_argument(kwargs, "pipeline_parallel_stages")
@@ -123,6 +123,8 @@ class _BaseAutoModelClass:
         inter_pp = kwargs.pop("inter_pp", None)
         intra_pp = kwargs.pop("intra_pp", None)
         transpose_value_cache = kwargs.pop("transpose_value_cache", True)
+        modules_to_not_convert = kwargs.pop("modules_to_not_convert", [])
+        print("modules_to_not_convert is !!!  ", modules_to_not_convert)
 
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
@@ -152,22 +154,30 @@ class _BaseAutoModelClass:
             )
             from ipex_llm.transformers.npu_models.convert_mp import optimize_llm, optimize_llm_pre
 
-            if model.config.model_type == "minicpmv":
+            if hasattr(model, "llm"):
                 llm = model.llm
-                if llm.config.hidden_size == 4096 and llm.config.vocab_size == 128256:
-                    # MiniCPM-llama3-V2.5
-                    llm.config.model_type = "llama"
             else:
                 llm = model
+            
+            if model.config.model_type == "minicpmv":
+                # MiniCPM-V
+                if model.config.hidden_size == 3584 and model.config.vocab_size == 151666:
+                    # MiniCPM-V 2.6
+                    model.llm.config.model_type = "qwen2"
 
             with torch.no_grad():
                 optimize_llm_pre(llm, qtype)
-                cls.load_convert(qtype, llm, "cpu", *args, **kwargs)
-                create_npu_kernels(llm)
+                cls.load_convert(qtype, model, "cpu", modules_to_not_convert, *args, **kwargs)
+                if hasattr(model, "llm"):
+                    create_npu_kernels(model.llm)
+                else:
+                    create_npu_kernels(model)
             model = model.eval()
             logger.info(f"Finish to convert model")
             model.config.update({"bigdl_transformers_low_bit": qtype})
             model.share_memory()
+
+            print("[debug] model type!!! ", llm.config.model_type)
 
             optimize_llm(
                 llm,
@@ -181,8 +191,11 @@ class _BaseAutoModelClass:
             from ipex_llm.transformers.npu_models.convert import optimize_llm
             optimize_llm(model)
             with torch.no_grad():
-                cls.load_convert(qtype, model, "cpu", *args, **kwargs)
-                create_npu_kernels(model)
+                cls.load_convert(qtype, model, "cpu", modules_to_not_convert, *args, **kwargs)
+                if hasattr(model, "llm"):
+                    create_npu_kernels(model.llm)
+                else:
+                    create_npu_kernels(model)
             model = model.eval()
             logger.info(f"Finish to convert model")
             model.config.update({"bigdl_transformers_low_bit": qtype})
@@ -192,10 +205,11 @@ class _BaseAutoModelClass:
         return model
 
     @classmethod
-    def load_convert(cls, q_k, optimize_model, device, *arg, **kwarg):
+    def load_convert(cls, q_k, optimize_model, device, modules_to_not_convert, *arg, **kwarg):
         from ipex_llm.transformers.npu_models.convert import replace_with_QuantizedLinear
 
-        replace_with_QuantizedLinear(optimize_model, q_k, device=device)
+        replace_with_QuantizedLinear(optimize_model, q_k, device=device,
+                                     modules_to_not_convert=modules_to_not_convert)
 
     @classmethod
     @patch("transformers.dynamic_module_utils.get_imports", patch_flash_attn_import)

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -41,6 +41,15 @@ def optimize_llm_pre(model: torch.nn.Module, qtype):
         if model.config.hidden_size in [4096, 2048]:
             from ipex_llm.transformers.models.baichuan import pre_compute_inv_freq
             model.apply(pre_compute_inv_freq)
+    
+    if model.config.model_type == "minicpmv":
+        # MiniCPM-V
+        if model.config.hidden_size == 2304 and model.config.vocab_size == 122753:
+            model.llm.config.model_type = "minicpm"
+        elif model.config.hidden_size == 3584 and model.config.vocab_size == 151666:
+            model.llm.config.model_type = "qwen2"
+        elif model.config.hidden_size == 4096 and model.config.vocab_size == 128256:
+            model.llm.config.model_type = "llama"
 
     # lm_head to cpu optimization
     if os.environ.get("IPEX_LLM_CPU_LM_HEAD", "0") != "0":

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -50,6 +50,7 @@ def optimize_llm_pre(model: torch.nn.Module, qtype):
             model.llm.config.model_type = "qwen2"
         elif model.config.hidden_size == 4096 and model.config.vocab_size == 128256:
             model.llm.config.model_type = "llama"
+        model = model.llm
 
     # lm_head to cpu optimization
     if os.environ.get("IPEX_LLM_CPU_LM_HEAD", "0") != "0":

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -41,7 +41,7 @@ def optimize_llm_pre(model: torch.nn.Module, qtype):
         if model.config.hidden_size in [4096, 2048]:
             from ipex_llm.transformers.models.baichuan import pre_compute_inv_freq
             model.apply(pre_compute_inv_freq)
-    
+
     if model.config.model_type == "minicpmv" and hasattr(model, "llm"):
         # MiniCPM-V
         if model.config.hidden_size == 2304 and model.config.vocab_size == 122753:

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -52,20 +52,19 @@ def optimize_llm_pre(model: torch.nn.Module, qtype):
             lm_qtype = SYM_INT8
         # lm_head opt to mp opt (llama, qwen2)
         optimize_lm_head = model.config.model_type not in ["llama", "qwen2"]
-        if hasattr(model, 'lm_head') and model.lm_head is not None:
-            new_linear = LowBitLinear(model.lm_head.in_features,
-                                      model.lm_head.out_features,
-                                      lm_qtype,
-                                      False,
-                                      optimize_lm_head=optimize_lm_head)
-            paramsLowBit = FP4Params(data=model.lm_head.weight.data,
-                                     requires_grad=False,
-                                     quantized=False,
-                                      _shape=None,
-                                     qtype=lm_qtype,
-                                     in_features=model.lm_head.in_features).to("cpu")
-            new_linear._parameters['weight'] = paramsLowBit
-            model.lm_head = new_linear
+        new_linear = LowBitLinear(model.lm_head.in_features,
+                                    model.lm_head.out_features,
+                                    lm_qtype,
+                                    False,
+                                    optimize_lm_head=optimize_lm_head)
+        paramsLowBit = FP4Params(data=model.lm_head.weight.data,
+                                    requires_grad=False,
+                                    quantized=False,
+                                    _shape=None,
+                                    qtype=lm_qtype,
+                                    in_features=model.lm_head.in_features).to("cpu")
+        new_linear._parameters['weight'] = paramsLowBit
+        model.lm_head = new_linear
 
 def optimize_llm(
     model: torch.nn.Module,

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -53,18 +53,19 @@ def optimize_llm_pre(model: torch.nn.Module, qtype):
         # lm_head opt to mp opt (llama, qwen2)
         optimize_lm_head = model.config.model_type not in ["llama", "qwen2"]
         new_linear = LowBitLinear(model.lm_head.in_features,
-                                    model.lm_head.out_features,
-                                    lm_qtype,
-                                    False,
-                                    optimize_lm_head=optimize_lm_head)
+                                  model.lm_head.out_features,
+                                  lm_qtype,
+                                  False,
+                                  optimize_lm_head=optimize_lm_head)
         paramsLowBit = FP4Params(data=model.lm_head.weight.data,
-                                    requires_grad=False,
-                                    quantized=False,
-                                    _shape=None,
-                                    qtype=lm_qtype,
-                                    in_features=model.lm_head.in_features).to("cpu")
+                                 requires_grad=False,
+                                 quantized=False,
+                                 _shape=None,
+                                 qtype=lm_qtype,
+                                 in_features=model.lm_head.in_features).to("cpu")
         new_linear._parameters['weight'] = paramsLowBit
         model.lm_head = new_linear
+
 
 def optimize_llm(
     model: torch.nn.Module,

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -42,7 +42,7 @@ def optimize_llm_pre(model: torch.nn.Module, qtype):
             from ipex_llm.transformers.models.baichuan import pre_compute_inv_freq
             model.apply(pre_compute_inv_freq)
     
-    if model.config.model_type == "minicpmv":
+    if model.config.model_type == "minicpmv" and hasattr(model, "llm"):
         # MiniCPM-V
         if model.config.hidden_size == 2304 and model.config.vocab_size == 122753:
             model.llm.config.model_type = "minicpm"

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -107,7 +107,6 @@ def optimize_llm(
         convert_forward(model, LlamaForCausalLM, llama2_casullm_forward)
     elif model.config.model_type == "qwen2" and model.config.num_hidden_layers == 28:
         # for qwen2-1.5B and qwen2-7B
-        print("[debug] enter qwen2 optimize llm !!!!!!")
         if intra_pp is None:
             intra_pp = 2
         if inter_pp is None:

--- a/python/llm/src/ipex_llm/transformers/npu_models/kv.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/kv.py
@@ -173,7 +173,8 @@ class DynamicFusedNormalCache(DynamicCache):
                 head_dim,
                 0,
                 max_len,
-                key_states.dtype,
+                # key_states.dtype,
+                torch.float16,
                 key_states.device,
                 tranpose_value=transpose_value,
             )

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -359,9 +359,9 @@ class LLMBaseNNFactory(NNFactory):
             for idx in indexes:
                 past_key = past_key_value.key_cache[idx]
                 past_value = past_key_value.value_cache[idx]
-                # invalidInputError(
-                #     past_key.dtype == torch.float16, f"past_key dtype is {past_key.dtype}"
-                # )
+                invalidInputError(
+                    past_key.dtype == torch.float16, f"past_key dtype is {past_key.dtype}"
+                )
                 new_size = (past_key.size(0), past_key.size(1), self.max_seq_len, past_key.size(3))
                 past_key = past_key.as_strided(new_size, past_key.stride(), storage_offset=0)
                 invalidInputError(past_key.is_contiguous(), "past_key is not contiguous")
@@ -383,7 +383,7 @@ class LLMBaseNNFactory(NNFactory):
             self.load_cache_async()
 
     def load_cache_async(self):
-        self.load_wt_fn(len(self.input_ops), self._mm, self.kv_cache_c_handle, verify_size=True)
+        self.load_wt_fn(len(self.input_ops), self._mm, self.kv_cache_c_handle)
 
     def set_weights(self, op_id, weights):
         self.set_weights_async(op_id, weights)
@@ -396,7 +396,7 @@ class LLMBaseNNFactory(NNFactory):
                           (f"weights size does not match graph, "
                            f"with weights size: {len(weights)} and "
                            f" graph linear size: {len(self.linear_ops)}"))
-        self.setWeights(offset, op_id, *weights, verify_size=True)
+        self.setWeights(offset, op_id, *weights)
 
     @staticmethod
     def run_decoders(inputs, decoders):

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -359,9 +359,9 @@ class LLMBaseNNFactory(NNFactory):
             for idx in indexes:
                 past_key = past_key_value.key_cache[idx]
                 past_value = past_key_value.value_cache[idx]
-                invalidInputError(
-                    past_key.dtype == torch.float16, f"past_key dtype is {past_key.dtype}"
-                )
+                # invalidInputError(
+                #     past_key.dtype == torch.float16, f"past_key dtype is {past_key.dtype}"
+                # )
                 new_size = (past_key.size(0), past_key.size(1), self.max_seq_len, past_key.size(3))
                 past_key = past_key.as_strided(new_size, past_key.stride(), storage_offset=0)
                 invalidInputError(past_key.is_contiguous(), "past_key is not contiguous")
@@ -383,7 +383,7 @@ class LLMBaseNNFactory(NNFactory):
             self.load_cache_async()
 
     def load_cache_async(self):
-        self.load_wt_fn(len(self.input_ops), self._mm, self.kv_cache_c_handle)
+        self.load_wt_fn(len(self.input_ops), self._mm, self.kv_cache_c_handle, verify_size=True)
 
     def set_weights(self, op_id, weights):
         self.set_weights_async(op_id, weights)
@@ -396,7 +396,7 @@ class LLMBaseNNFactory(NNFactory):
                           (f"weights size does not match graph, "
                            f"with weights size: {len(weights)} and "
                            f" graph linear size: {len(self.linear_ops)}"))
-        self.setWeights(offset, op_id, *weights)
+        self.setWeights(offset, op_id, *weights, verify_size=True)
 
     @staticmethod
     def run_decoders(inputs, decoders):

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -1133,8 +1133,6 @@ def generate_qwen2_attention_forward(max_seq_len, transpose_value):
 
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
-        key_states = key_states.half()
-        value_states = value_states.half()
 
         attn_weights = None
         if query_states.size(2) == key_states.size(2):

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -756,8 +756,7 @@ def run_prefill(
     input_layer_norm_weights = []
     post_attn_layernorm_weights = []
     layer_indexs = range(layer_start, layer_end)
-    # if model.config.intermediate_size == 8960:
-    if True:
+    if model.config.intermediate_size == 8960:
         # for qwen2-1.5b
         for layer_idx in layer_indexs:
             curr_layer = model.model.layers[layer_idx]
@@ -807,8 +806,7 @@ def run_prefill(
     print("finish creating all decode layers in prefill")
     result_queue.put("loading finish")
 
-    # if model.config.intermediate_size == 18944:
-    if False:
+    if model.config.intermediate_size == 18944:
         # for qwen2-7b
         from transformers.models.qwen2.modeling_qwen2 import Qwen2Attention
         from ipex_llm.transformers.npu_models.convert_mp import convert_forward

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -371,7 +371,6 @@ class FusedQwenLowBitMultiDecoderlayer(torch.nn.Module):
         hidden_states, new_keys, new_values = LowBitQwenMultiDecoderlayer.run_decoders(
             inputs,
             decoders=self.backend_decoders)
-        print("[debug] finish run_decoders")
 
         if self.do_print:
             print("outputs:", hidden_states)


### PR DESCRIPTION
## Description


### 1. Why the change?

- Initial NPU support for MiniCPM-V-2_6 : put LLM on NPU and keep other part on CPU.
- add initial NPU example script
- add `modules_to_not_convert` support

- [ ]  TODO: update readme of Multimodal directory

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
