### PR TITLE
Fix glm4-9b-chat nan error on vllm 0.3.3

### DIFF
--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -249,12 +249,12 @@ def get_load_function(low_bit):
                                    scheduler_config=self.scheduler_config)
             from ipex_llm import optimize_model
             import os
-            not_convert_last_mlp = os.getenv("IPEX_LLM_NOT_CONVERT_MLP", None)
+            not_convert_last_mlp = os.getenv("IPEX_LLM_NOT_CONVERT_LAST_MLP", None)
             if not_convert_last_mlp is not None:
                 # only use to avoid nan value in last mlp forward running glm4-9b-chat
-                modules=["35.mlp", "36.mlp", "37.mlp", "38.mlp", "39.mlp"]
+                modules = ["35.mlp", "36.mlp", "37.mlp", "38.mlp", "39.mlp"]
             else:
-                modules=None
+                modules = None
             optimize_model(self.model, low_bit=low_bit, torch_dtype=self.model_config.dtype,
                            modules_to_not_convert=modules)
             self.model = self.model.to(device=self.device_config.device,

--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -248,7 +248,15 @@ def get_load_function(low_bit):
                                    parallel_config=self.parallel_config,
                                    scheduler_config=self.scheduler_config)
             from ipex_llm import optimize_model
-            optimize_model(self.model, low_bit=low_bit, torch_dtype=self.model_config.dtype)
+            import os
+            not_convert_last_mlp = os.getenv("IPEX_LLM_NOT_CONVERT_MLP", None)
+            if not_convert_last_mlp is not None:
+                # only use to avoid nan value in last mlp forward running glm4-9b-chat
+                modules=["35.mlp", "36.mlp", "37.mlp", "38.mlp", "39.mlp"]
+            else:
+                modules=None
+            optimize_model(self.model, low_bit=low_bit, torch_dtype=self.model_config.dtype,
+                           modules_to_not_convert=modules)
             self.model = self.model.to(device=self.device_config.device,
                                        dtype=self.model_config.dtype)
 


### PR DESCRIPTION
## Description
Refer to https://github.com/analytics-zoo/nano/issues/1544#issuecomment-2309163575. Use env `IPEX_LLM_NOT_CONVERT_LAST_MLP` to not convert last MLP to avoid nan error running glm4-chat-9b.
Then the output will be normal but the blocks will reduce (26488-25261 = 1227), and the next_token prefomance will reduce 0-1ms.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
