### PR TITLE
Fix wrong attention mask and garbage output for `inputs_embeds` inputs during lookup generation

### DIFF
--- a/python/llm/src/ipex_llm/transformers/lookup.py
+++ b/python/llm/src/ipex_llm/transformers/lookup.py
@@ -175,14 +175,13 @@ class PromptLookupCandidateGenerator():
 
     def init_look_up_table(self,
                            input_ids: torch.LongTensor):
-        for ngram_size in range(self.max_matching_ngram_size, 0, -1):
-            if ngram_size <= input_ids.shape[1]:
-                # Create sliding windows of size ngram_size
-                windows = input_ids.cpu().unfold(dimension=1, size=ngram_size, step=1)
-                for idx in range(windows.size(1)):
-                    window = tensor2key(windows[0, idx])
-                    if window not in self.lookup_table:
-                        self.lookup_table[window] = idx
+        for ngram_size in range(min(self.max_matching_ngram_size, input_ids.shape[1]), 0, -1):
+            # Create sliding windows of size ngram_size
+            windows = input_ids.cpu().unfold(dimension=1, size=ngram_size, step=1)
+            for idx in range(windows.size(1)):
+                window = tensor2key(windows[0, idx])
+                if window not in self.lookup_table:
+                    self.lookup_table[window] = idx
 
     def update_look_up_table(self,
                              new_input_ids: torch.LongTensor):

--- a/python/llm/src/ipex_llm/transformers/lookup.py
+++ b/python/llm/src/ipex_llm/transformers/lookup.py
@@ -315,11 +315,9 @@ def lookup_generate(self,
         if step == 0:
             # first token use full model
             tic = time.time()
-            output = self(input_ids=input_ids,
-                          past_key_values=past_key_values,
-                          attention_mask=attention_mask,
-                          return_dict=True,
-                          use_cache=True)
+            model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
+            output = self(**model_inputs,
+                          return_dict=True)
             logits = output['logits']
             logits = logits[:, -1:]
             logits[:, -1, :] = logits_processor(input_ids, logits[:, -1, :])

--- a/python/llm/src/ipex_llm/transformers/lookup.py
+++ b/python/llm/src/ipex_llm/transformers/lookup.py
@@ -176,12 +176,13 @@ class PromptLookupCandidateGenerator():
     def init_look_up_table(self,
                            input_ids: torch.LongTensor):
         for ngram_size in range(self.max_matching_ngram_size, 0, -1):
-            # Create sliding windows of size ngram_size
-            windows = input_ids.cpu().unfold(dimension=1, size=ngram_size, step=1)
-            for idx in range(windows.size(1)):
-                window = tensor2key(windows[0, idx])
-                if window not in self.lookup_table:
-                    self.lookup_table[window] = idx
+            if ngram_size <= input_ids.shape[1]:
+                # Create sliding windows of size ngram_size
+                windows = input_ids.cpu().unfold(dimension=1, size=ngram_size, step=1)
+                for idx in range(windows.size(1)):
+                    window = tensor2key(windows[0, idx])
+                    if window not in self.lookup_table:
+                        self.lookup_table[window] = idx
 
     def update_look_up_table(self,
                              new_input_ids: torch.LongTensor):


### PR DESCRIPTION
## Description

Fix wrong attention mask and garbage output for `inputs_embeds` inputs during lookup generation

Minicpm-V-2_6 multimodal input:
- before:
  ![image](https://github.com/user-attachments/assets/6fddb483-3d87-4023-96d6-9a30fd37223b)
- after:
  ![image](https://github.com/user-attachments/assets/d5cbee63-4a6d-4281-9630-783556b010ef)
