### PR TITLE
Support lm_head of minicpm-2b on NPU

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -219,8 +219,10 @@ def optimize_llm(
             prefill_runner=prefill_runner, decode_runner=decode_runner
         )
         convert_forward(model, module.MiniCPMModel, minicpm_model_forward)
-        from ipex_llm.transformers.npu_models.minicpm_mp import minicpm_casullm_forward
-        convert_forward(model, module.MiniCPMForCausalLM, minicpm_casullm_forward)
+        if model.config.num_hidden_layers == 40:
+            # for minicpm-2b
+            from ipex_llm.transformers.npu_models.minicpm_mp import minicpm_casullm_forward
+            convert_forward(model, module.MiniCPMForCausalLM, minicpm_casullm_forward)
     elif model.config.model_type == "baichuan" and model.config.num_hidden_layers == 32:
         # for Baichuan2-7B
         if intra_pp is None:

--- a/python/llm/src/ipex_llm/transformers/npu_models/minicpm_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/minicpm_mp.py
@@ -985,3 +985,80 @@ def gen_minicpm_fused_model_forward(prefill_runner, decode_runner):
         )
 
     return minicpm_fused_model_forward
+
+
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from torch.nn import CrossEntropyLoss
+def minicpm_casullm_forward(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[List[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+) -> Union[Tuple, CausalLMOutputWithPast]:
+    print('======REPLACE!!!!!')
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+    )
+
+    hidden_states = outputs[0]
+    if self.config.pretraining_tp > 1:
+        lm_head_slices = self.lm_head.weight.split(self.vocab_size // self.config.pretraining_tp, dim=0)
+        logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.config.pretraining_tp)]
+        logits = torch.cat(logits, dim=-1)
+    else:
+        ### ipex-llm change start
+        # logits = self.lm_head(hidden_states / (self.config.hidden_size / self.config.dim_model_base))
+        hidden_states_1, hidden_states_2 = hidden_states.split([1536, 768], dim=-1)
+        print(f'hidden_states_1 shape {hidden_states_1.shape}, hidden_states_2 shape {hidden_states_2.shape}, ')
+        logits1 = self.lm_head_0(hidden_states_1 / (self.config.hidden_size / self.config.dim_model_base))
+        logits2 = self.lm_head_1(hidden_states_2 / (self.config.hidden_size / self.config.dim_model_base))
+        logits = logits1 + logits2
+        ### ipex-llm change end
+    logits = logits.float()
+
+    loss = None
+    if labels is not None:
+        # Shift so that tokens < n predict n
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+        # Flatten the tokens
+        loss_fct = CrossEntropyLoss()
+        shift_logits = shift_logits.view(-1, self.config.vocab_size)
+        shift_labels = shift_labels.view(-1)
+        # Enable model parallelism
+        shift_labels = shift_labels.to(shift_logits.device)
+        loss = loss_fct(shift_logits, shift_labels)
+
+    if not return_dict:
+        output = (logits,) + outputs[1:]
+        return (loss,) + output if loss is not None else output
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )

--- a/python/llm/src/ipex_llm/transformers/npu_models/minicpm_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/minicpm_mp.py
@@ -1002,7 +1002,6 @@ def minicpm_casullm_forward(
     output_hidden_states: Optional[bool] = None,
     return_dict: Optional[bool] = None,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
-    print('======REPLACE!!!!!')
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -1029,12 +1028,9 @@ def minicpm_casullm_forward(
         logits = torch.cat(logits, dim=-1)
     else:
         ### ipex-llm change start
-        # logits = self.lm_head(hidden_states / (self.config.hidden_size / self.config.dim_model_base))
-        hidden_states_1, hidden_states_2 = hidden_states.split([1536, 768], dim=-1)
-        print(f'hidden_states_1 shape {hidden_states_1.shape}, hidden_states_2 shape {hidden_states_2.shape}, ')
-        logits1 = self.lm_head_0(hidden_states_1 / (self.config.hidden_size / self.config.dim_model_base))
-        logits2 = self.lm_head_1(hidden_states_2 / (self.config.hidden_size / self.config.dim_model_base))
-        logits = logits1 + logits2
+        logits1 = self.lm_head_0(hidden_states / (self.config.hidden_size / self.config.dim_model_base))
+        logits2 = self.lm_head_1(hidden_states / (self.config.hidden_size / self.config.dim_model_base))
+        logits = torch.cat((logits1, logits2[:, :,:49313]), dim=-1)
         ### ipex-llm change end
     logits = logits.float()
 


### PR DESCRIPTION
## Description

We have to put lm_head of minicpm-2b on CPU now because windows error during `logits = self.lm_head(hidden_states / (self.config.hidden_size / self.config.dim_model_base))`

As a workaround, we could split lm_head as two linear and padding the 2nd part.

### 2. User API changes

N/A

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] Application test (verified on MTL and LNL, https://github.com/intel-analytics/llm-npu/issues/15#issuecomment-2330654788)