### PR TITLE
Select the Appropriate APT Repository Based on CPU Type

### DIFF
--- a/docs/mddocs/Quickstart/install_linux_gpu.md
+++ b/docs/mddocs/Quickstart/install_linux_gpu.md
@@ -19,14 +19,25 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
 
 #### For Linux kernel 6.2
 
-* Install wget, gpg-agent
-    ```bash
-    sudo apt-get install -y gpg-agent wget
-    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
-    sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
-    echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
-    sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
-    ```
+* Choose one option below depending on your CPU type:
+
+  1. **Option 1**: For `Intel Core CPU` with multiple A770 Arc GPUs. Use the following repository:
+      ```bash
+      sudo apt-get install -y gpg-agent wget
+      wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+      sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+      echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
+      sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+      ```
+
+  2. **Option 2**: For `Intel Xeon-W/SP CPU` with multiple A770 Arc GPUs. Use this repository for better performance:
+      ```bash
+      wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+      sudo gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+      echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 unified" | \
+      sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+      sudo apt update
+      ```
 
     <img src="https://llm-assets.readthedocs.io/en/latest/_images/wget.png" width=100%; />
 
@@ -71,14 +82,25 @@ IPEX-LLM currently supports the Ubuntu 20.04 operating system and later, and sup
 
 #### For Linux kernel 6.5
 
-* Install wget, gpg-agent
-    ```bash
-    sudo apt-get install -y gpg-agent wget
-    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
-    sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
-    echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
-    sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
-    ```
+* Choose one option below depending on your CPU type:
+
+  1. **Option 1**: For `Intel Core CPU` with multiple A770 Arc GPUs. Use the following repository:
+      ```bash
+      sudo apt-get install -y gpg-agent wget
+      wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+      sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+      echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
+      sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+      ```
+
+  2. **Option 2**: For `Intel Xeon-W/SP CPU` with multiple A770 Arc GPUs. Use this repository for better performance:
+      ```bash
+      wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+      sudo gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+      echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 unified" | \
+      sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+      sudo apt update
+      ```
 
     <img src="https://llm-assets.readthedocs.io/en/latest/_images/wget.png" width=100%; />
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This update addresses issues discovered with the APT repository configuration for Xeon-W + Multi-Arc machines. We observed that using the repository `deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client` led to problems with the Level Zero runtime, particularly with versions 26241 and 27191. Version 26241 has known issues, and version 27191 experienced out-of-memory (OOM) errors, as detailed in issue https://github.com/analytics-zoo/nano/issues/1575#issuecomment-2323940468.

After switching to the repository `deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 unified`, we found that the Level Zero runtime versions 26241 and 27191 functioned without issues. Additionally, this repository provides better performance overall.

Therefore, we have updated the documentation to recommend using the `deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 unified` repository for users working with Xeon-W + Multi-Arc workstations.

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [x] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
