### PR TITLE
Enable Qwen padding mlp to 256 to support batch_forward

### DIFF
--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -227,7 +227,7 @@ def get_load_function(low_bit):
                 cache_config=self.cache_config,
             )
             if "qwen" in self.model_config.model.lower() and \
-                self.model.model.layers[0].mlp.down_proj.input_size_per_partition % 64 != 0:
+                self.model.model.layers[0].mlp.down_proj.input_size_per_partition % 256 != 0:
                 self.model.apply(padding_mlp)
             from ipex_llm import optimize_model
             import os
@@ -255,7 +255,7 @@ def padding_mlp(module: torch.nn.Module):
         hidden_size = module.down_proj.output_size
         # devide by rank
         intermediate_size = module.down_proj.input_size_per_partition
-        padding_size = 64
+        padding_size = 256
         padding_intermediate_size = (intermediate_size + padding_size - 1) // padding_size * padding_size
         if intermediate_size % padding_size == 0:
             return

--- a/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
+++ b/python/llm/src/ipex_llm/vllm/xpu/model_convert.py
@@ -226,6 +226,9 @@ def get_load_function(low_bit):
                 scheduler_config=self.scheduler_config,
                 cache_config=self.cache_config,
             )
+            if "qwen" in self.model_config.model.lower() and \
+                self.model.model.layers[0].mlp.down_proj.input_size_per_partition % 64 != 0:
+                self.model.apply(padding_mlp)
             from ipex_llm import optimize_model
             import os
             not_convert_last_mlp = os.getenv("IPEX_LLM_NOT_CONVERT_LAST_MLP", None)
@@ -246,3 +249,29 @@ def get_load_function(low_bit):
                     self.model_memory_usage / float(2**30))
 
     return _ipex_llm_load_model
+
+def padding_mlp(module: torch.nn.Module):
+    if isinstance(module, Qwen2MLP):
+        hidden_size = module.down_proj.output_size
+        # devide by rank
+        intermediate_size = module.down_proj.input_size_per_partition
+        padding_size = 64
+        padding_intermediate_size = (intermediate_size + padding_size - 1) // padding_size * padding_size
+        if intermediate_size % padding_size == 0:
+            return
+        gate_up_weight = module.gate_up_proj.weight.data
+        new_gate_up_weight = torch.zeros([padding_intermediate_size * 2, hidden_size],
+                                      dtype=gate_up_weight.dtype, device=gate_up_weight.device)
+        # merge_gate_up_weight
+        new_gate_up_weight[:intermediate_size, :] = gate_up_weight[:intermediate_size, :]
+        new_gate_up_weight[padding_intermediate_size:padding_intermediate_size+intermediate_size, :] = gate_up_weight[intermediate_size:, :]
+        module.gate_up_proj.output_size_per_partition = padding_intermediate_size * 2
+        module.gate_up_proj.weight = torch.nn.Parameter(new_gate_up_weight, requires_grad=False)
+
+
+        down_weight = module.down_proj.weight.data
+        new_down_weight = torch.zeros([hidden_size, padding_intermediate_size],
+                                      dtype=down_weight.dtype, device=down_weight.device)
+        new_down_weight[:, :intermediate_size] = down_weight
+        module.down_proj.input_size_per_partition = padding_intermediate_size
+        module.down_proj.weight = torch.nn.Parameter(new_down_weight, requires_grad=False)


### PR DESCRIPTION
## Description
Enable Qwen padding mlp to speed-up next_token on batch_forward.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
