### PR TITLE
Add input padding during prefill for qwen2-7b

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -931,8 +931,21 @@ class PrefillRunner:
                 " to max_prompt_len {self.max_prompt_len}"
             ),
         )
-        self.prefill_input_queue.put((hidden_states, position_ids, attention_mask, past_key_value))
-        return self.prefill_result_queue.get()
+        pad_len = self.max_prompt_len - seq_len
+        hidden_states = F.pad(hidden_states.to(torch.float16), (0, 0, 0, pad_len), value=0.0)
+        position_ids = F.pad(position_ids, (0, pad_len), value=0)
+        attention_mask = F.pad(
+            attention_mask.to(torch.float16),
+            (0, pad_len, 0, pad_len),
+            value=torch.finfo(torch.float16).min,
+        )
+
+        args = (hidden_states, position_ids, attention_mask, past_key_value)
+        self.prefill_input_queue.put(args)
+        hidden_states, past_key_value = self.prefill_result_queue.get()
+        past_key_value.shrink(seq_len, self.transpose_value_cache)
+        hidden_states = hidden_states[:, :seq_len, :]
+        return hidden_states, past_key_value
 
     def shutdown(self):
         self.prefill_input_queue.put("stop")


### PR DESCRIPTION
## Description

Related to https://github.com/intel-analytics/ipex-llm/issues/12025

For qwen2-7b with `max-output-len=1024` and `max-prompt-len=512`, if input_lenth==336, following compile error exists:
```bash
input length: 336
start compiling
loc(fused<{name = "Add_1106", type = "Add"}>["Add_1106", "_mem_permute_1"]): error: PermuteCast input and output distributions are incompatible: in = #VPU.DistributedTensor<mode = <SEGMENTED>, num_tiles = [1, 4, 1, 1], num_clusters = 4 : i64, uniform_distributed_segments = unit, compute_shapes = [[1, 7, 336, 128], [1, 7, 336, 128], [1, 7, 336, 128], [1, 7, 336, 128]], compute_offsets = [[0, 0, 0, 0], [0, 7, 0, 0], [0, 14, 0, 0], [0, 21, 0, 0]], memory_shapes = [[1, 7, 336, 128], [1, 7, 336, 128], [1, 7, 336, 128], [1, 7, 336, 128]], memory_offsets = [[0, 0, 0, 0], [0, 7, 0, 0], [0, 14, 0, 0], [0, 21, 0, 0]]>, out = #VPU.DistributedTensor<mode = <OVERLAPPED>, num_tiles = [1, 1, 4, 1], num_clusters = 4 : i64, uniform_distributed_segments = unit, compute_shapes = [[1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336]], compute_offsets = [[0, 0, 0, 0], [0, 0, 7, 0], [0, 0, 14, 0], [0, 0, 21, 0]], memory_shapes = [[1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336]], memory_offsets = [[0, 0, 0, 0], [0, 0, 7, 0], [0, 0, 14, 0], [0, 0, 21, 0]]>,expected = #VPU.DistributedTensor<mode = <SEGMENTED>, num_tiles = [1, 1, 4, 1], num_clusters = 4 : i64, uniform_distributed_segments = unit, compute_shapes = [[1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336]], compute_offsets = [[0, 0, 0, 0], [0, 0, 7, 0], [0, 0, 14, 0], [0, 0, 21, 0]], memory_shapes = [[1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336], [1, 128, 7, 336]], memory_offsets = [[0, 0, 0, 0], [0, 0, 7, 0], [0, 0, 14, 0], [0, 0, 21, 0]]>
Process Process-5:
Traceback (most recent call last):
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\ipex_llm\transformers\npu_models\qwen2_mp.py", line 875, in run_prefill
    layer_outputs = decoder_layer(
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\torch\nn\modules\module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\torch\nn\modules\module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\ipex_llm\transformers\npu_models\qwen2_mp.py", line 514, in forward
    hidden_states, past_key, past_value = run_model(
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\torch\utils\_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\ipex_llm\transformers\npu_models\mp_models_base.py", line 75, in run_model
    _model_cache[key] = deque([backend_cls(*input_shapes) for i in range(replica)])
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\ipex_llm\transformers\npu_models\mp_models_base.py", line 75, in <listcomp>
    _model_cache[key] = deque([backend_cls(*input_shapes) for i in range(replica)])
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\ipex_llm\transformers\npu_models\qwen2_mp.py", line 225, in __init__
    self.compile()
  File "C:\Users\2-4\miniforge3\envs\binbin-npu\lib\site-packages\intel_npu_acceleration_library\backend\factory.py", line 837, in compile
    backend_lib.compile(self._mm)
OSError: [WinError -529697949] Windows Error 0xe06d7363
```

Add input padding in prefill process, therefore, such error could be work around. Besides, for different prompt length, we don't need to compile every time.

### 4. How to test?
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] Application test
Have verified correctness of qwen2-1.5b and qwen2-7b on LNL with 32.0.100.2761 and 32.0.101.2715
![image](https://github.com/user-attachments/assets/41f950f7-2a4d-4bf4-8db1-1198a2a0ccb7)


**Will fix correctness on MTL later**