### PR TITLE
fix ipex_llm import in transformers 4.45

### DIFF
--- a/python/llm/src/ipex_llm/utils/__init__.py
+++ b/python/llm/src/ipex_llm/utils/__init__.py
@@ -22,7 +22,9 @@ import transformers
 
 trans_version = transformers.__version__
 
-if trans_version >= "4.43.0":
+if trans_version >= "4.45.0":
+    pass
+elif trans_version >= "4.43.0":
     from .benchmark_util_4_43 import BenchmarkWrapper
 elif trans_version >= "4.42.0":
     from .benchmark_util_4_42 import BenchmarkWrapper


### PR DESCRIPTION
## Description

import `BenchmarkWrapper` will raise error in transformers 4.45, so disable its import in transformers 4.45
