### PR TITLE
use english prompt in vllm_online_benchmark.py

### DIFF
--- a/docker/llm/serving/xpu/docker/vllm_online_benchmark.py
+++ b/docker/llm/serving/xpu/docker/vllm_online_benchmark.py
@@ -435,12 +435,14 @@ LLM_URLS = [f"http://localhost:{PORT}/v1/completions" for PORT in [8000]]
 MODEL = "/llm/models/" + model_name
 MAX_TOKENS = output_length  # 修改 MAX_TOKENS 为 output_length
 
-if "Qwen" not in MODEL and "chatglm" not in MODEL:
-    # print("using Llama PROMPT")
-    PROMPT = ENGLISH_PROMPT
-else:
-    # print("using Qwen/chatglm PROMPT")
-    PROMPT = CHINESE_PROMPT
+# if "Qwen" not in MODEL and "chatglm" not in MODEL:
+#     print("using Llama PROMPT")
+#     PROMPT = ENGLISH_PROMPT
+# else:
+#     print("using Qwen/chatglm PROMPT")
+#     PROMPT = CHINESE_PROMPT
+
+PROMPT = ENGLISH_PROMPT
 
 # 加载模型的 tokenizer
 from transformers import AutoTokenizer


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

We found that when running Qwen2.5-7B-Instruct with batch=4, there is an error when using Chinese prompts, but no issue when switching to English prompts. Therefore, for now, this PR will be modified to use English prompts to collect performance data, and @hzjane will continue investigating the cause of the error with Chinese prompts.
<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
