### PR TITLE
optimize openjourney

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/sd15.py
+++ b/python/llm/src/ipex_llm/transformers/models/sd15.py
@@ -1,0 +1,139 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Some parts of this file is adapted from
+# https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py
+# which is licensed under Apache License 2.0:
+#
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import math
+import torch
+from typing import Optional
+
+from ipex_llm.transformers.models.common import attention_softmax
+from diffusers.models.attention_processor import Attention
+
+
+class AttnProcessor2_0:
+    r"""
+    Processor for implementing scaled dot-product attention.
+    """
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        temb: Optional[torch.Tensor] = None,
+        *args,
+        **kwargs,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask,
+                                                         sequence_length, batch_size)
+            # scaled_dot_product_attention expects attention_mask shape to be
+            # (batch, heads, source_length, target_length)
+            attention_mask = attention_mask.view(batch_size, attn.heads,
+                                                 -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        elif attn.norm_cross:
+            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # IPEX-LLM changes start
+        if head_dim in [40, 80]:
+            import xe_test
+            hidden_states = xe_test.sdp_non_causal(query, key.contiguous(),
+                                                   value.contiguous(), attention_mask)
+        else:
+            scale = 1 / math.sqrt(head_dim)
+            attn_weights = torch.matmul(query * scale, key.transpose(-1, -2))
+            if attention_mask is not None:
+                attn_weights = attn_weights + attention_mask
+            attn_weights = attention_softmax(attn_weights, False)
+            hidden_states = torch.matmul(attn_weights, value)
+        # IPEX-LLM changes end
+
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1,
+                                                              attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel,
+                                                                    height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states


### PR DESCRIPTION
## Description

optimize openjourney by optimizing its attention

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

use `ipex_llm.transformers.models.sd15.AttnProcessor2_0` instead of default attention implementation

```python
import time
import torch
from diffusers import StableDiffusionPipeline
from ipex_llm.transformers.models.sd15 import AttnProcessor2_0


model_id = "prompthero/openjourney"

pipe = StableDiffusionPipeline.from_pretrained(
    model_id,
    torch_dtype=torch.float16,
    use_safetensors=True,
)
pipe.unet.set_attn_processor(AttnProcessor2_0())
pipe = pipe.to("xpu")

with torch.inference_mode():
    for i in range(3):
        st = time.time()
        prompt = "retro serie of different cars with different colors and shapes, mdjrny-v4 style"
        image = pipe(prompt, num_inference_steps=20).images[0]
        et = time.time()
        print(et - st)
        image.save("./retro_cars.png")

```
<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
