### PR TITLE
vLLM: Set block_size from 16 to 8

### DIFF
--- a/docker/llm/serving/xpu/docker/benchmark_vllm_throughput.py
+++ b/docker/llm/serving/xpu/docker/benchmark_vllm_throughput.py
@@ -88,6 +88,7 @@ def run_vllm(
               seed=seed,
               trust_remote_code=trust_remote_code,
               dtype=dtype,
+              block_size=8,
               max_model_len=max_model_len,
               gpu_memory_utilization=gpu_memory_utilization,
               enforce_eager=enforce_eager,

--- a/docker/llm/serving/xpu/docker/start-vllm-service.sh
+++ b/docker/llm/serving/xpu/docker/start-vllm-service.sh
@@ -23,6 +23,7 @@ python -m ipex_llm.vllm.xpu.entrypoints.openai.api_server \
   --device xpu \
   --dtype float16 \
   --enforce-eager \
+  --block-size 8 \
   --load-in-low-bit fp8 \
   --max-model-len 2048 \
   --max-num-batched-tokens 4000 \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Set block_size from 16 to 8 for better performance on Arc.