### PR TITLE
LNL windows release

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -46,6 +46,8 @@ exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 IPEX_LLM_PYTHON_HOME = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VERSION = open(os.path.join(IPEX_LLM_PYTHON_HOME,
                './llm/version.txt'), 'r').read().strip()
+# temp change for test release version
+VERSION = "2.2.0b20241008.dev0"
 CORE_XE_VERSION = VERSION.replace("2.2.0", "2.6.0")
 llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 github_artifact_dir = os.path.join(llm_home, '../llm-binary')

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -47,6 +47,9 @@ IPEX_LLM_PYTHON_HOME = os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 VERSION = open(os.path.join(IPEX_LLM_PYTHON_HOME,
                './llm/version.txt'), 'r').read().strip()
 CORE_XE_VERSION = VERSION.replace("2.2.0", "2.6.0")
+# temp commit for test
+VERSION = "2.2.0b20241008.dev1"
+CORE_XE_VERSION = "2.6.0b20241008.dev0"
 llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 github_artifact_dir = os.path.join(llm_home, '../llm-binary')
 libs_dir = os.path.join(llm_home, "ipex_llm", "libs")

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -297,15 +297,15 @@ def setup_package():
     # default to ipex 2.1 for linux and windows
     xpu_requires = copy.deepcopy(xpu_21_requires)
 
-    lnl_requires = copy.deepcopy(all_requires)
+    xpu_23_requires = copy.deepcopy(all_requires)
     for exclude_require in cpu_torch_version:
-        lnl_requires.remove(exclude_require)
-    lnl_requires += ["torch==2.3.1+cxx11.abi",
-                     "torchvision==0.18.1+cxx11.abi",
-                     "intel-extension-for-pytorch==2.3.110+xpu",
-                     "bigdl-core-xe-23==" + CORE_XE_VERSION,
-                     "bigdl-core-xe-batch-23==" + CORE_XE_VERSION,
-                     "bigdl-core-xe-addons-23==" + CORE_XE_VERSION]
+        xpu_23_requires.remove(exclude_require)
+    xpu_23_requires += ["torch==2.3.1+cxx11.abi",
+                        "torchvision==0.18.1+cxx11.abi",
+                        "intel-extension-for-pytorch==2.3.110+xpu",
+                        "bigdl-core-xe-23==" + CORE_XE_VERSION,
+                        "bigdl-core-xe-batch-23==" + CORE_XE_VERSION,
+                        "bigdl-core-xe-addons-23==" + CORE_XE_VERSION]
 
     cpp_requires = ["bigdl-core-cpp==" + CORE_XE_VERSION,
                     "onednn-devel==2024.2.1;platform_system=='Windows'"]
@@ -345,7 +345,7 @@ def setup_package():
                         "xpu": xpu_requires,  # default to ipex 2.1 for linux and windows
                         "npu": npu_requires,
                         "xpu-2-1": xpu_21_requires,
-                        "lnl": lnl_requires,
+                        "xpu-2-3": xpu_23_requires,
                         "serving": serving_requires,
                         "cpp": cpp_requires,
                         "llama-index": llama_index_requires}, # for internal usage when upstreaming for llama-index

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -46,8 +46,6 @@ exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 IPEX_LLM_PYTHON_HOME = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VERSION = open(os.path.join(IPEX_LLM_PYTHON_HOME,
                './llm/version.txt'), 'r').read().strip()
-# temp change for test release version
-VERSION = "2.2.0b20241008.dev0"
 CORE_XE_VERSION = VERSION.replace("2.2.0", "2.6.0")
 llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 github_artifact_dir = os.path.join(llm_home, '../llm-binary')
@@ -297,15 +295,15 @@ def setup_package():
     # default to ipex 2.1 for linux and windows
     xpu_requires = copy.deepcopy(xpu_21_requires)
 
-    xpu_23_requires = copy.deepcopy(all_requires)
+    xpu_lnl_requires = copy.deepcopy(all_requires)
     for exclude_require in cpu_torch_version:
-        xpu_23_requires.remove(exclude_require)
-    xpu_23_requires += ["torch==2.3.1+cxx11.abi",
-                        "torchvision==0.18.1+cxx11.abi",
-                        "intel-extension-for-pytorch==2.3.110+xpu",
-                        "bigdl-core-xe-23==" + CORE_XE_VERSION,
-                        "bigdl-core-xe-batch-23==" + CORE_XE_VERSION,
-                        "bigdl-core-xe-addons-23==" + CORE_XE_VERSION]
+        xpu_lnl_requires.remove(exclude_require)
+    xpu_lnl_requires += ["torch==2.3.1+cxx11.abi",
+                         "torchvision==0.18.1+cxx11.abi",
+                         "intel-extension-for-pytorch==2.3.110+xpu",
+                         "bigdl-core-xe-23==" + CORE_XE_VERSION,
+                         "bigdl-core-xe-batch-23==" + CORE_XE_VERSION,
+                         "bigdl-core-xe-addons-23==" + CORE_XE_VERSION]
 
     cpp_requires = ["bigdl-core-cpp==" + CORE_XE_VERSION,
                     "onednn-devel==2024.2.1;platform_system=='Windows'"]
@@ -345,7 +343,7 @@ def setup_package():
                         "xpu": xpu_requires,  # default to ipex 2.1 for linux and windows
                         "npu": npu_requires,
                         "xpu-2-1": xpu_21_requires,
-                        "xpu-2-3": xpu_23_requires,
+                        "xpu-lnl": xpu_lnl_requires,
                         "serving": serving_requires,
                         "cpp": cpp_requires,
                         "llama-index": llama_index_requires}, # for internal usage when upstreaming for llama-index

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -47,9 +47,6 @@ IPEX_LLM_PYTHON_HOME = os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 VERSION = open(os.path.join(IPEX_LLM_PYTHON_HOME,
                './llm/version.txt'), 'r').read().strip()
 CORE_XE_VERSION = VERSION.replace("2.2.0", "2.6.0")
-# temp commit for test
-VERSION = "2.2.0b20241008.dev1"
-CORE_XE_VERSION = "2.6.0b20241008.dev0"
 llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 github_artifact_dir = os.path.join(llm_home, '../llm-binary')
 libs_dir = os.path.join(llm_home, "ipex_llm", "libs")

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -295,6 +295,15 @@ def setup_package():
     # default to ipex 2.1 for linux and windows
     xpu_requires = copy.deepcopy(xpu_21_requires)
 
+    lnl_requires = copy.deepcopy(all_requires)
+    for exclude_require in cpu_torch_version:
+        lnl_requires.remove(exclude_require)
+    lnl_requires += ["torch==2.3.1+cxx11.abi",
+                     "torchvision==0.18.1+cxx11.abi",
+                     "intel-extension-for-pytorch==2.3.110+xpu",
+                     "bigdl-core-xe-23==" + CORE_XE_VERSION,
+                     "bigdl-core-xe-batch-23==" + CORE_XE_VERSION,
+                     "bigdl-core-xe-addons-23==" + CORE_XE_VERSION]
 
     cpp_requires = ["bigdl-core-cpp==" + CORE_XE_VERSION,
                     "onednn-devel==2024.2.1;platform_system=='Windows'"]
@@ -334,6 +343,7 @@ def setup_package():
                         "xpu": xpu_requires,  # default to ipex 2.1 for linux and windows
                         "npu": npu_requires,
                         "xpu-2-1": xpu_21_requires,
+                        "lnl": lnl_requires,
                         "serving": serving_requires,
                         "cpp": cpp_requires,
                         "llama-index": llama_index_requires}, # for internal usage when upstreaming for llama-index


### PR DESCRIPTION
## Description

Add support to release `ipex-llm` for Windows users on LNL.

### How to install on LNL iGPU Windows

```cmd
conda create -n ipex-llm-lnl python=3.11 libuv
conda activate ipex-llm-lnl

pip install --pre --upgrade ipex-llm[xpu_lnl] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/lnl/us/
:: or --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/lnl/cn/
```

### How to run on LNL iGPU Windows

```cmd
conda activate ipex-llm-lnl 
set SYCL_CACHE_PERSISTENT=1
python test.py
```

> [!NOTE]
> Currently if install `ipex-llm[xpu_lnl]` on Linux, users will directly meet package not found error

> [!NOTE]
> Users need `import intel_extension_for_pytorch` before using any `xpu` operation, `import ipex_llm` won't import ipex automatically for `xpu_lnl`
