### PR TITLE
fix pydantic.errors.PydanticUserError

### DIFF
--- a/python/llm/src/ipex_llm/langchain/embeddings/bigdlllm.py
+++ b/python/llm/src/ipex_llm/langchain/embeddings/bigdlllm.py
@@ -49,7 +49,7 @@ import logging
 import importlib
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, Field, root_validator
+from pydantic.v1 import BaseModel, Extra, Field, root_validator
 
 from langchain.embeddings.base import Embeddings
 from .transformersembeddings import TransformersEmbeddings

--- a/python/llm/src/ipex_llm/langchain/llms/bigdlllm.py
+++ b/python/llm/src/ipex_llm/langchain/llms/bigdlllm.py
@@ -48,7 +48,7 @@ import logging
 import importlib
 from typing import Any, Dict, Generator, List, Optional
 
-from pydantic import Field, root_validator
+from pydantic.v1 import Field, root_validator
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM


### PR DESCRIPTION
fix in pydantic>2.0,  pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.