### PR TITLE
update NPU pipeline generate

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/pipeline_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/pipeline_model.py
@@ -131,7 +131,7 @@ def generate(
             break
         token = int.from_bytes(data, sys.byteorder)
         idx += 1
-        if time_t1 == None:
+        if time_t1 is None:
             time_t1 = time.perf_counter()
         output_tokens.append(torch.tensor([token]))
         if streamer is not None:
@@ -152,7 +152,8 @@ def generate(
         print(f" Number of input tokens: {input_length}")
         print(f" Generated tokens: {idx}")
         print(f" First token generation time: {(time_t1 - time_start):.2f} s")
-        print(f" Generation average latency: {(time_end - time_t1)*1000 /(idx - 1):.2f} ms, ({(idx - 1)/(time_end - time_t1):.2f} token/s)")
+        print(f" Generation average latency: {(time_end - time_t1)*1000 /(idx - 1):.2f} ms, "
+              f"({(idx - 1)/(time_end - time_t1):.2f} token/s)")
         print(f" Generation time: {(time_end - time_start):.2f} s\n")
 
     return output


### PR DESCRIPTION
## Description


### 1. Why the change?

-  Add timing logic to the generate function. When generate accepts `do_print=True`, print these timing information
- When we set `max_new_tokens`=32, now actually output 33  tokens,  fix this issue
- transformer's generate actually return input_tokens  + output_tokens, now we only return output_tokens, fix this issue

### 2. User API changes

No change.

### 3. Summary of the change 


### 4. How to test?
- [x] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [x] Application test