### PR TITLE
add vLLM `--blocksize 8` to docs and scripts

### DIFF
--- a/docker/llm/serving/xpu/docker/start-vllm-service.sh
+++ b/docker/llm/serving/xpu/docker/start-vllm-service.sh
@@ -19,6 +19,7 @@ python -m ipex_llm.vllm.xpu.entrypoints.openai.api_server \
   --port 8000 \
   --model $model \
   --trust-remote-code \
+  --block-size 8 \
   --gpu-memory-utilization 0.9 \
   --device xpu \
   --dtype float16 \

--- a/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
@@ -103,6 +103,7 @@ Before performing benchmark or starting the service, you can refer to this [sect
 |`--max-model-len`| Model context length. If unspecified, will be automatically derived from the model config.|
 |`--max-num-batched-token`| Maximum number of batched tokens per iteration.|
 |`--max-num-seq`| Maximum number of sequences per iteration. Default: 256|
+|`--block-size`| vLLM block size. Set to 8 to achieve a performance boost.|
 
 #### Single card serving
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
add vLLM `--blocksize 8` to docs and scripts, set to 8 to achieve a performance boost.
<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
