### PR TITLE
Support cpp release for ARL on Windows

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -47,6 +47,9 @@ IPEX_LLM_PYTHON_HOME = os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 VERSION = open(os.path.join(IPEX_LLM_PYTHON_HOME,
                './llm/version.txt'), 'r').read().strip()
 CORE_XE_VERSION = VERSION.replace("2.2.0", "2.6.0")
+# temp change for test
+VERSION = "2.2.0b20241011.dev0"
+CORE_XE_VERSION = "2.6.0b20241011"
 llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 github_artifact_dir = os.path.join(llm_home, '../llm-binary')
 libs_dir = os.path.join(llm_home, "ipex_llm", "libs")

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -309,6 +309,10 @@ def setup_package():
                     "onednn-devel==2024.2.1;platform_system=='Windows'"]
     cpp_requires += oneapi_2024_2_requires
 
+    cpp_arl_requires = ["bigdl-core-cpp==" + CORE_XE_VERSION,
+                        "onednn-devel==2024.1.1;platform_system=='Windows'"]
+    cpp_arl_requires += oneapi_2024_2_requires
+
     serving_requires = ['py-cpuinfo']
     serving_requires += SERVING_DEP
 
@@ -347,6 +351,7 @@ def setup_package():
                         "xpu-arl": xpu_lnl_requires,
                         "serving": serving_requires,
                         "cpp": cpp_requires,
+                        "cpp-arl": cpp_arl_requires,
                         "llama-index": llama_index_requires}, # for internal usage when upstreaming for llama-index
         classifiers=[
             'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
## Description

Add support to release `ipex-llm` cpp for Windows users on ARL.
- Add option `ipex-llm[cpp_arl]` with onednn 2024.1

> [!NOTE]
> Currently `ipex-llm[cpp_arl]` can also be successfully installed on Linux, but with no onednn 2024.1 pip dependency