### PR TITLE
fix code geex  no attribute 'gradient_checkpointing'

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/chatglm2.py
+++ b/python/llm/src/ipex_llm/transformers/models/chatglm2.py
@@ -183,7 +183,7 @@ def chatglm2_encoder_forward(
     if not kv_caches and not use_compress_kv:
         kv_caches = [None for _ in range(self.num_layers)]
     presents = () if use_cache else None
-    if self.gradient_checkpointing and self.training:
+    if hasattr(self, "gradient_checkpointing") and self.gradient_checkpointing and self.training:
         use_cache = False
 
     all_self_attentions = None
@@ -193,7 +193,8 @@ def chatglm2_encoder_forward(
             all_hidden_states = all_hidden_states + (hidden_states,)
 
         layer = self._get_layer(index)
-        if self.gradient_checkpointing and self.training:
+        if hasattr(self, "gradient_checkpointing") and self.gradient_checkpointing \
+                and self.training:
             layer_ret = torch.utils.checkpoint.checkpoint(
                 layer,
                 hidden_states,


### PR DESCRIPTION
## Description

fix code geex 
```
  File "/home/arda/miniforge3/envs/xin-llm/lib/python3.11/site-packages/ipex_llm/transformers/models/chatglm2.py", line 186, in chatglm2_encoder_forward
    if self.gradient_checkpointing and self.training:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arda/miniforge3/envs/xin-llm/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1695, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'GLMTransformer' object has no attribute 'gradient_checkpointing'

```

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
