### PR TITLE
[fix] vllm-online-benchmark first token latency error

### DIFF
--- a/docker/llm/serving/xpu/docker/vllm_online_benchmark.py
+++ b/docker/llm/serving/xpu/docker/vllm_online_benchmark.py
@@ -270,13 +270,7 @@ def perform_request(session, url, payload, headers):
                         json_data = json.loads(data)
                         if 'choices' in json_data and len(json_data['choices']) > 0:
                             choice = json_data['choices'][0]
-                            if 'finish_reason' in choice and (choice['finish_reason'] == 'length' or choice['finish_reason'] == 'stop'):
-                                if 'first_token_time' in choice and isinstance(choice['first_token_time'], float):
-                                    first_token_inference_time = choice['first_token_time']
-                                if 'rest_token_time' in choice and isinstance(choice['rest_token_time'], float):
-                                    next_token_inference_time = choice['rest_token_time']
-                            else:
-                                # 记录第一个token的时间
+                            if 'text' in choice:
                                 if first_token_time is None:
                                     first_token_time = token_time
                                 else:


### PR DESCRIPTION
## Description
* Problem: When benchmark the output length is 1, the first token latency will ben none and lead to error. And when the output length is 2, the first token latency will be ok, but next token latency will be nan. The reason is the `token_time` will not be computed for the choice in json don't have `first_token_time` and `rest_token_time` which is required in the code.
![image](https://github.com/user-attachments/assets/f8794720-5dca-485a-b0cd-6b0abc440574)
* Solution: When the `text` in choice, and `first_token_time` is None, we should compute it.
* Verified result:
![image](https://github.com/user-attachments/assets/8e97b5b6-84d4-4d7b-866c-8bc699503682)


