### PR TITLE
Patch sdpa check function in specific module attributes table

### DIFF
--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -542,7 +542,7 @@ class _BaseAutoModelClass:
 
     @classmethod
     @patch("transformers.dynamic_module_utils.get_imports", patch_flash_attn_import)
-    @patch("transformers.utils.is_torch_sdpa_available", patch_sdpa_available, create=True)
+    @patch("transformers.modeling_utils.is_torch_sdpa_available", patch_sdpa_available, create=True)
     def load_low_bit(cls,
                      pretrained_model_name_or_path,
                      *model_args,

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -113,7 +113,7 @@ class _BaseAutoModelClass:
     HF_MODEL = None
 
     @classmethod
-    @patch("transformers.dynamic_module_utils.get_imports", patch_flash_attn_import)
+    @patch("transformers.modeling_utils.is_torch_sdpa_available", patch_sdpa_available)
     @patch("transformers.utils.is_torch_sdpa_available", patch_sdpa_available, create=True)
     def from_pretrained(cls,
                         *args,

--- a/python/llm/src/ipex_llm/transformers/model.py
+++ b/python/llm/src/ipex_llm/transformers/model.py
@@ -113,8 +113,8 @@ class _BaseAutoModelClass:
     HF_MODEL = None
 
     @classmethod
-    @patch("transformers.modeling_utils.is_torch_sdpa_available", patch_sdpa_available)
-    @patch("transformers.utils.is_torch_sdpa_available", patch_sdpa_available, create=True)
+    @patch("transformers.dynamic_module_utils.get_imports", patch_flash_attn_import)
+    @patch("transformers.modeling_utils.is_torch_sdpa_available", patch_sdpa_available, create=True)
     def from_pretrained(cls,
                         *args,
                         **kwargs):

--- a/python/llm/src/ipex_llm/transformers/patches.py
+++ b/python/llm/src/ipex_llm/transformers/patches.py
@@ -17,7 +17,6 @@
 
 from typing import List
 from transformers.dynamic_module_utils import get_imports
-from transformers.utils import is_torch_sdpa_available
 from ipex_llm.utils.ipex_importer import IPEXImporter
 
 

--- a/python/llm/src/ipex_llm/transformers/patches.py
+++ b/python/llm/src/ipex_llm/transformers/patches.py
@@ -18,6 +18,7 @@
 from typing import List
 from transformers.dynamic_module_utils import get_imports
 from transformers.utils import is_torch_sdpa_available
+from ipex_llm.utils.ipex_importer import IPEXImporter
 
 
 def patch_flash_attn_import(filename: str) -> List[str]:
@@ -29,8 +30,7 @@ def patch_flash_attn_import(filename: str) -> List[str]:
 
 
 def patch_sdpa_available() -> bool:
-    import torch
-    if "cxx" in torch.__version__:
+    if IPEXImporter.is_xpu_version_installed():
         return False
     else:
         return is_torch_sdpa_available()

--- a/python/llm/src/ipex_llm/transformers/patches.py
+++ b/python/llm/src/ipex_llm/transformers/patches.py
@@ -17,6 +17,7 @@
 
 from typing import List
 from transformers.dynamic_module_utils import get_imports
+from transformers.utils import is_torch_sdpa_available
 
 
 def patch_flash_attn_import(filename: str) -> List[str]:
@@ -28,4 +29,8 @@ def patch_flash_attn_import(filename: str) -> List[str]:
 
 
 def patch_sdpa_available() -> bool:
-    return False
+    import torch
+    if "cxx" in torch.__version__:
+        return False
+    else:
+        return is_torch_sdpa_available()

--- a/python/llm/src/ipex_llm/transformers/patches.py
+++ b/python/llm/src/ipex_llm/transformers/patches.py
@@ -33,4 +33,8 @@ def patch_sdpa_available() -> bool:
     if IPEXImporter.is_xpu_version_installed():
         return False
     else:
-        return is_torch_sdpa_available()
+        try:
+            from transformers.utils import is_torch_sdpa_available
+            return is_torch_sdpa_available()
+        except ImportError:
+            return False


### PR DESCRIPTION
## Description
When a module import another module, they maintain a copy of the attributes ref table from the imported module.
before this PR:
```
(Pdb)  print(transformers.modeling_utils.is_torch_sdpa_available)
<function is_torch_sdpa_available at 0x000002594D5A4540>
(Pdb)  print(transformers.utils.is_torch_sdpa_available)
<function patch_sdpa_available at 0x0000025951C031A0>
(Pdb)  print(transformers.utils.import_utils.is_torch_sdpa_available)
<function is_torch_sdpa_available at 0x000002594D5A4540>
(Pdb) print(patch_sdpa_available)
<function patch_sdpa_available at 0x0000025951C031A0>
```
after this PR
```
(Pdb) print(transformers.modeling_utils.is_torch_sdpa_available)
<function patch_sdpa_available at 0x000001ECD0CF31A0>
(Pdb) print(transformers.utils.is_torch_sdpa_available)
<function is_torch_sdpa_available at 0x000001ECCD65C540>
(Pdb) print(transformers.utils.import_utils.is_torch_sdpa_available)
<function is_torch_sdpa_available at 0x000001ECCD65C540>
(Pdb) print(patch_sdpa_available)
<function patch_sdpa_available at 0x000001ECD0CF31A0>
```