### PR TITLE
Add minicpm-2b in L0 pipeline

### DIFF
--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/Pipeline-Models/README.md
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/Pipeline-Models/README.md
@@ -10,7 +10,7 @@ In this directory, you will find examples on how to directly run HuggingFace `tr
 | Llama3 | [meta-llama/Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct) |
 | Qwen2.5 | [Qwen/Qwen2.5-7b-Instruct](https://huggingface.co/Qwen/Qwen2.5-7b-Instruct) |
 | Baichuan2 | [baichuan-inc/Baichuan2-7B-Chat](https://huggingface.co/baichuan-inc/Baichuan-7B-Chat) |
-| MiniCPM | [openbmb/MiniCPM-1B-sft-bf16](https://huggingface.co/openbmb/MiniCPM-1B-sft-bf16) |
+| MiniCPM | [openbmb/MiniCPM-1B-sft-bf16](https://huggingface.co/openbmb/MiniCPM-1B-sft-bf16), [openbmb/MiniCPM-2B-sft-bf16](https://huggingface.co/openbmb/MiniCPM-2B-sft-bf16) |
 
 ## 0. Requirements
 To run these examples with IPEX-LLM on Intel NPUs, make sure to install the newest driver version of Intel NPU.
@@ -55,6 +55,9 @@ python baichuan2.py
 
 :: to run MiniCPM-1B-sft-bf16
 python minicpm.py
+
+:: to run MiniCPM-2B-sft-bf16
+python minicpm.py --repo-id-or-model-path "openbmb/MiniCPM-2B-sft-bf16"
 ```
 
 Arguments info:

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/Pipeline-Models/minicpm.py
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/Pipeline-Models/minicpm.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--repo-id-or-model-path",
         type=str,
-        default="openbmb/MiniCPM-1B-sft-bf16",
+        default="openbmb/MiniCPM-1B-sft-bf16", # or "openbmb/MiniCPM-2B-sft-bf16"
         help="The huggingface repo id for the MiniCPM model to be downloaded"
         ", or the path to the huggingface checkpoint folder",
     )

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -362,7 +362,7 @@ def convert_llm(model: torch.nn.Module,
         invalidInputError(False, "Now we only support Llama2 / Llama3 / Baichuan2 / "
                                  "Qwen2 / Qwen2.5 / Minicpm for pipeline running.")
 
-    if isinstance(model.lm_head, SlicedLMHead):
+    if hasattr(model, "lm_head") and isinstance(model.lm_head, SlicedLMHead):
         model.lm_head.get_fused_lm_head()
 
     # patch generate function

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
@@ -171,9 +171,9 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir):
             weight_numpy = [model.lm_head_0.weight.data.numpy(),
                             model.lm_head_0.scale.data.numpy(),
                             model.lm_head_1.weight.data.numpy(),
-                            model.lm_head_1.scale.data.numpy(),]
+                            model.lm_head_1.scale.data.numpy(), ]
         else:
-            weight_numpy = [model.lm_head.weight.data.numpy(), model.lm_head.scale.data.numpy(),]
+            weight_numpy = [model.lm_head.weight.data.numpy(), model.lm_head.scale.data.numpy(), ]
     else:
         # TODO
         pass


### PR DESCRIPTION
## Description

Add minicpm-2b support in L0 pipeline. Currently, we have to split lm_head and pad 2nd submodule (https://github.com/intel-analytics/ipex-llm/pull/12019), otherwise exist compile error.
Update related implementation is L0 pipeline.

![image](https://github.com/user-attachments/assets/bd96e062-2613-4805-a7c2-45386786739c)


### 4. How to test?
- [x] Application test
Details in https://github.com/analytics-zoo/nano/issues/1706#issuecomment-2449389756
