### PR TITLE
[NPU] Add env to disable compile opt

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/llama_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/llama_mp.py
@@ -196,7 +196,7 @@ class LowBitLlamaMultiDecoderlayer(LLMBaseNNFactory):
             new_value_states = self.convert_to_fp16(curr_key_values[i][1])
 
         print("start compiling")
-        if mode == "prefill":
+        if mode == "prefill" and os.environ.get("IPEX_LLM_NPU_DISABLE_COMPILE_OPT", "0") != "1":
             self.compile(npu_dpu_groups=6)
         else:
             self.compile()

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -232,7 +232,8 @@ class LowBitQwenMultiDecoderlayer(LLMBaseNNFactory):
             new_value_states = self.convert_to_fp16(curr_key_values[i][1])
 
         print(f"{mode} start compiling")
-        if (group_size != 0
+        if (
+            group_size != 0
             and (mode == "prefill" or num_layers == 2)
             and os.environ.get("IPEX_LLM_NPU_DISABLE_COMPILE_OPT", "0") != "1"
         ):

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -232,7 +232,9 @@ class LowBitQwenMultiDecoderlayer(LLMBaseNNFactory):
             new_value_states = self.convert_to_fp16(curr_key_values[i][1])
 
         print(f"{mode} start compiling")
-        if group_size != 0 and (mode == "prefill" or num_layers == 2):
+        if (group_size != 0
+            and (mode == "prefill" or num_layers == 2)
+            and os.environ.get("IPEX_LLM_NPU_DISABLE_COMPILE_OPT", "0") != "1"):
             self.compile(npu_dpu_groups=6)
         else:
             self.compile()

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -234,7 +234,8 @@ class LowBitQwenMultiDecoderlayer(LLMBaseNNFactory):
         print(f"{mode} start compiling")
         if (group_size != 0
             and (mode == "prefill" or num_layers == 2)
-            and os.environ.get("IPEX_LLM_NPU_DISABLE_COMPILE_OPT", "0") != "1"):
+            and os.environ.get("IPEX_LLM_NPU_DISABLE_COMPILE_OPT", "0") != "1"
+        ):
             self.compile(npu_dpu_groups=6)
         else:
             self.compile()


### PR DESCRIPTION
## Description

Add env to disable compile optimization.

Usage:
set IPEX_LLM_NPU_DISABLE_COMPILE_OPT=1

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
