### PR TITLE
fix ipex 2.3 bug

### DIFF
--- a/python/llm/src/ipex_llm/utils/ipex_importer.py
+++ b/python/llm/src/ipex_llm/utils/ipex_importer.py
@@ -146,6 +146,12 @@ class IPEXImporter:
 
         Raises ImportError and invalidInputError if failed
         """
+
+        # insert a fake module to avoid importing real `intel_extension_for_pytorch.llm`
+        # which will replace some `transformers`'s functions and bring some bugs in ipex 2.3
+        from ipex_llm.utils.modules import insert_fake_module
+        insert_fake_module("intel_extension_for_pytorch.llm", "fake module")
+
         # import ipex
         import intel_extension_for_pytorch as ipex
         if ipex is not None:

--- a/python/llm/src/ipex_llm/utils/modules.py
+++ b/python/llm/src/ipex_llm/utils/modules.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from types import ModuleType
+
+
+def insert_fake_module(name, doc=None):
+    m = ModuleType(name, doc)
+    m.__file__ = __file__
+    sys.modules[name] = m
+    return m


### PR DESCRIPTION
## Description

ipex 2.3 will replace some `transformers`'s functions, which may cause error

insert a fake module before importing ipex to avoid it

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...
