### PR TITLE
update vllm-docker-quick-start for vllm0.6.2

### DIFF
--- a/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
+++ b/docs/mddocs/DockerGuides/vllm_docker_quickstart.md
@@ -250,7 +250,6 @@ python -m ipex_llm.vllm.xpu.entrypoints.openai.api_server \
   --load-in-low-bit sym_int4 \
   --max-model-len 2048 \
   --max-num-batched-tokens 4000 \
-  --max-num-seqs 12 \
   --tensor-parallel-size 1 \
   --disable-async-output-proc \
   --distributed-executor-backend ray
@@ -681,7 +680,6 @@ python -m ipex_llm.vllm.xpu.entrypoints.openai.api_server \
   --load-in-low-bit fp8 \
   --max-model-len 4096 \
   --max-num-batched-tokens 10240 \
-  --max-num-seqs 12 \
   --tensor-parallel-size 1 \
   --distributed-executor-backend ray \
   --enable-lora \
@@ -774,7 +772,6 @@ python -m ipex_llm.vllm.xpu.entrypoints.openai.api_server \
   --load-in-low-bit fp8 \
   --max-model-len 2048 \
   --max-num-batched-tokens 4000 \
-  --max-num-seqs 12 \
   --api-key <your-api-key> \
   --tensor-parallel-size 4 \
   --distributed-executor-backend ray


### PR DESCRIPTION
## Description

change example code for starting vllm serving, add `--distributed-executor-backend ray` parameter
