### PR TITLE
use new q4_0 batch kernel

### DIFF
--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -362,10 +362,8 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
     batch_size = x.shape[0]
     hard_condition = (
         x.dtype in [torch.float, torch.half]
-        and ((
-                x.shape[1] % 128 == 0
-                and qtype in [SYM_INT4]
-            )
+        and (
+            x.shape[1] % 128 == 0 and qtype in [SYM_INT4]
             or (
                 x.shape[1] % 256 == 0
                 and output_len % 32 == 0

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -362,12 +362,18 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
     batch_size = x.shape[0]
     hard_condition = (
         x.dtype in [torch.float, torch.half]
-        and x.shape[1] % 256 == 0
-        and output_len % 32 == 0
-        and device in ["arc", "flex", "pvc", "mtl"]
-        and qtype in [SYM_INT4, ASYM_INT4, SYM_INT8, FP4,
-                      FP8E5, FP6, FP8E4, Q4_K, Q6_K]
-        and batch_size <= 64
+        and ((
+                x.shape[1] % 128 == 0
+                and qtype in [SYM_INT4]
+            )
+            or (
+                x.shape[1] % 256 == 0
+                and output_len % 32 == 0
+                and device in ["arc", "flex", "pvc", "mtl"]
+                and qtype in [ASYM_INT4, SYM_INT8, FP4, FP8E5, FP6, FP8E4, Q4_K, Q6_K]
+            )
+        )
+        and batch_size <= 48
     )
     if hard_condition:
         return (


### PR DESCRIPTION
## Description

new batch kernel supports more device, requires state_size % 128 == 0 instead of state_size % 256 == 0, remove output_size % 32 == 0, but it supports max batch to 48 instead of 64

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
- [ ] Application test
- [ ] Document test
- [ ] ...
