### PR TITLE
[NPU] change attention_mask to fp16

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/minicpm_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/minicpm_mp.py
@@ -125,10 +125,10 @@ class LowBitMinicpmMultiDecoderlayer(LLMBaseNNFactory):
         # Self Attention
         if mode == "decode":
             attention_mask = self.create_input_op((self.batch_size, 1, 1, self.max_seq_len + 1),
-                                                  dtype=np.int64)
+                                                  dtype=np.float16)
         else:
             attention_mask = self.create_input_op((self.batch_size, 1, self.seq_len, self.seq_len),
-                                                  dtype=np.int64)
+                                                  dtype=np.float16)
 
         position_ids = self.create_input_op((self.batch_size, self.seq_len), dtype=np.int64)
 
@@ -357,7 +357,7 @@ class FusedLlamaLowBitMultiDecoderlayer(torch.nn.Module):
 
         inputs = (
             hidden_states.to(torch.float16),
-            attention_mask.to(torch.int64),
+            attention_mask.to(torch.float16),
             position_ids.to(torch.int64),
         )
 
@@ -475,7 +475,7 @@ class FusedLlamaLowBitDecoderlayer(torch.nn.Module):
 
         backend_cls = self.backend_cls_prefill
         inputs = (hidden_states.to(torch.float16),
-                  attention_mask.to(torch.int64),
+                  attention_mask.to(torch.float16),
                   position_ids.to(torch.int64))
         inputs += (self.layer_norm_0, self.layer_norm_1)
         hidden_states, past_key, past_value = run_model(
@@ -599,7 +599,7 @@ def run_decode(
                 past_key_values = input_queue.get()
             else:
                 past_seen_tokens = past_key_values.get_seq_length()
-                attention_mask = torch.ones([1, past_seen_tokens + 1], dtype=torch.int64)
+                attention_mask = torch.ones([1, past_seen_tokens + 1], dtype=torch.float16)
                 cache_position = torch.arange(
                     past_seen_tokens, past_seen_tokens + 1, device=hidden_states.device
                 )
@@ -878,9 +878,9 @@ class PrefillRunner:
         hidden_states = F.pad(hidden_states.to(torch.float16), (0, 0, 0, pad_len), value=0.0)
         position_ids = F.pad(position_ids, (0, pad_len), value=0)
         attention_mask = F.pad(
-            attention_mask.to(torch.int64),
+            attention_mask.to(torch.float16),
             (0, pad_len, 0, pad_len),
-            value=torch.iinfo(torch.int64).min,
+            value=torch.finfo(torch.float16).min,
         )
 
         args = (hidden_states, position_ids, attention_mask, past_key_value)

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -247,8 +247,6 @@ class LLMBaseNNFactory(NNFactory):
             attn_weight = self.matmul(query_states, key_states, False, True) / (
                 math.sqrt(head_dim)
             )
-            if mode != "prefill":
-                attention_mask = self.convert_to_fp16(attention_mask)
             attn_weight = self.eltwise_add(attn_weight, attention_mask)
             attn_weight = self.convert_to_fp32(attn_weight)
             attn_weight = self.softmax(attn_weight, -1)


### PR DESCRIPTION
## Description

Change attention mask from int64 node to fp16, update related logic.


### 2. User API changes

N/A


### 4. How to test?
- [x] Application test
Verified correctness of Baichuan2-7B-Chat & Llama-2-7b-chat-hf & MiniCPM-1B-sft-bf16 & Qwen2-1.5B-Instruct & Qwen2-7B-Instruct of both npu-acc-lib and L0 pipeline examples/