### PR TITLE
[NPU] dump prefill IR for further C++ solution

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -239,6 +239,8 @@ class _BaseAutoModelClass:
         inter_pp = kwargs.pop("inter_pp", None)
         intra_pp = kwargs.pop("intra_pp", None)
         transpose_value_cache = kwargs.pop("transpose_value_cache", True)
+        compile_full_model = kwargs.pop('compile_full_model', False)
+        save_directory = kwargs.pop('save_directory', None)
 
         if hasattr(model, "llm"):
             llm = model.llm

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -134,6 +134,8 @@ class _BaseAutoModelClass:
         mixed_precision = kwargs.pop('mixed_precision', False)
         quantization_group_size = kwargs.pop("quantization_group_size", 0)
         mock_device = kwargs.pop('device', None)  # For mock on CPU
+        compile_full_model = kwargs.pop('compile_full_model', False)
+        save_directory = kwargs.pop('save_directory', None)
 
         invalidInputError(
             quantization_group_size in [0, 32, 64, 128],
@@ -197,7 +199,9 @@ class _BaseAutoModelClass:
                     "max_prompt_len": max_prompt_len,
                     "inter_pp": inter_pp,
                     "intra_pp": intra_pp,
-                    "transpose_value_cache": transpose_value_cache
+                    "transpose_value_cache": transpose_value_cache,
+                    "compile_full_model": compile_full_model,
+                    "save_directory": save_directory,
                 }
                 model = cls.optimize_npu_model(*args, **optimize_kwargs)
             else:
@@ -271,7 +275,9 @@ class _BaseAutoModelClass:
                         kv_len=max_context_len,
                         max_prompt_len=max_prompt_len,
                         transpose_value_cache=transpose_value_cache,
-                        group_size=quantization_group_size)
+                        group_size=quantization_group_size,
+                        compile_full_model=compile_full_model,
+                        save_directory=save_directory)
         model.save_low_bit = types.MethodType(save_low_bit, model)
         return model
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -135,7 +135,10 @@ class LLMEmbedding(NNFactory):
         self.dtype = dtype
 
         # define input
-        weight = self.constant(embedding_weight)
+        if input_length > 1:
+            weight = self.parameter((vocab_size, embedding_dim))
+        else:
+            weight = self.constant(embedding_weight)
         input = self.parameter((1, input_length), dtype=np.int32)
 
         if padding_idx == -1:

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -35,7 +35,7 @@ def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True
     core.set_property("NPU", {"NPU_COMPILATION_MODE_PARAMS":
                               "compute-layers-with-higher-precision=Sqrt,Power,ReduceMean,Add"})
     core.set_property("NPU", {"PERFORMANCE_HINT": "LATENCY"})
-    print(xml_path)
+
     model = core.read_model(xml_path)
     inputs = model.inputs
     for idx, input in enumerate(inputs):
@@ -56,7 +56,6 @@ def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True
             f.write(model_stream)
 
     os.remove(xml_path)
-    # os.remove(bin_path)
 
     if not keep_ir:
         os.remove(new_ir_path)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -23,7 +23,7 @@ from intel_npu_acceleration_library.backend.factory import NNFactory
 import numpy as np
 
 
-def update_names_of_IR_and_export_blob(model, model_name, dir):
+def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True):
     xml_path = os.path.join(dir, model_name + ".xml")
     model.save(xml_path)
     new_ir_path = os.path.join(dir, model_name + "_new.xml")
@@ -47,7 +47,7 @@ def update_names_of_IR_and_export_blob(model, model_name, dir):
     if new_ir_path is not None:
         serialize(model, new_ir_path)
 
-    if blob_path is not None:
+    if compile_blob:
         compiledModel = core.compile_model(model, device_name="NPU")
         model_stream = compiledModel.export_model()
         with open(blob_path, 'wb') as f:

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -33,6 +33,7 @@ def update_names_of_IR_and_export_blob(model, model_name, dir):
     core.set_property("NPU", {"NPU_COMPILATION_MODE_PARAMS":
                               "compute-layers-with-higher-precision=Sqrt,Power,ReduceMean,Add"})
     core.set_property("NPU", {"PERFORMANCE_HINT": "LATENCY"})
+    print(xml_path)
     model = core.read_model(xml_path)
     inputs = model.inputs
     for idx, input in enumerate(inputs):
@@ -53,7 +54,7 @@ def update_names_of_IR_and_export_blob(model, model_name, dir):
             f.write(model_stream)
 
     os.remove(xml_path)
-    os.remove(new_ir_path)
+    # os.remove(new_ir_path)
 
     return blob_path
 
@@ -94,7 +95,8 @@ class LowBitLLMLMHead(LLMBaseNNFactory):
         if n_splits == 1:
             input = self.create_input_op((self.batch_size, self.seq_len, self.hidden_size))
         else:
-            input = self.create_input_op((1, self.batch_size, self.hidden_size))
+            # input = self.create_input_op((1, self.batch_size, self.hidden_size))
+            input = self.create_input_op((self.batch_size, self.seq_len, self.hidden_size))
 
         hidden_states = input
 
@@ -123,6 +125,7 @@ class LLMEmbedding(NNFactory):
         embedding_weight,
         padding_idx,
         dtype,  # fp16
+        input_length: int = 1,
         device: str = "NPU",
     ):
         super().__init__(False, device)
@@ -133,7 +136,7 @@ class LLMEmbedding(NNFactory):
 
         # define input
         weight = self.constant(embedding_weight)
-        input = self.parameter((1, 1), dtype=np.int32)
+        input = self.parameter((1, input_length), dtype=np.int32)
 
         if padding_idx == -1:
             padding_idx += vocab_size

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -56,7 +56,7 @@ def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True
             f.write(model_stream)
 
     os.remove(xml_path)
-    os.remove(bin_path)
+    # os.remove(bin_path)
 
     if not keep_ir:
         os.remove(new_ir_path)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -333,11 +333,7 @@ def convert_llm(model: torch.nn.Module,
         with tempfile.TemporaryDirectory() as temp_dir:
             if save_directory is not None:
                 temp_dir = save_directory
-            temp_dir = r"D:\ruonan\qwen2.5-7B-full-weights-512-new"
-            if os.path.exists(temp_dir):
-                import shutil
-                shutil.rmtree(temp_dir)
-            os.mkdir(temp_dir)
+                os.mkdir(temp_dir)
             weight_dir = os.path.join(temp_dir, "model_weights")
             os.mkdir(weight_dir)
             layer_num = len(model.model.layers)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -333,7 +333,7 @@ def convert_llm(model: torch.nn.Module,
         with tempfile.TemporaryDirectory() as temp_dir:
             if save_directory is not None:
                 temp_dir = save_directory
-            temp_dir = r"D:\ruonan\qwen2-1.5B-full-weights-960"
+            temp_dir = r"D:\ruonan\qwen2.5-7B-full-weights-512-new"
             if os.path.exists(temp_dir):
                 import shutil
                 shutil.rmtree(temp_dir)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -352,8 +352,8 @@ def convert_llm(model: torch.nn.Module,
 
             if compile_full_model:
                 convert_qwen_layer(model, 0, n_splits_linear, n_splits_down_proj,
-                                   temp_dir, weight_dir, transpose_value_cache, max_prompt_len, group_size,
-                                   layernorm_const, "prefill")
+                                   temp_dir, weight_dir, transpose_value_cache, max_prompt_len,
+                                   group_size, layernorm_const, "prefill")
 
             # Prefill Runner
             from ipex_llm.transformers.npu_models.convert_mp import convert_qwen

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -371,6 +371,16 @@ def convert_llm(model: torch.nn.Module,
             model.transpose_value_cache = transpose_value_cache
             model.vocab_size = model.config.vocab_size
 
+            if save_directory is not None:
+                update_dict = {"kv_len": kv_len, "num_head": model.num_head,
+                               "head_dim": model.head_dim,
+                               "transpose_value_cache": transpose_value_cache,
+                               "max_prompt_len": max_prompt_len,
+                               "layernorm_const": layernorm_const,
+                               "group_size":  group_size}
+                model.config.update(update_dict)
+                model.config.save_pretrained(save_directory)
+
             try:
                 res = InitLLMPipeline("qwen", kv_len, model.num_head, model.head_dim, layer_num,
                                       model.vocab_size, weight_dir, "model",

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -350,9 +350,9 @@ def convert_llm(model: torch.nn.Module,
                 result = pool.starmap(convert_qwen_layer, param_list)
             
             if compile_full_model:
-                from .qwen import convert_qwen_prefill_layer, convert_lm_head_and_embedding
-                convert_qwen_prefill_layer(model, n_splits_linear, n_splits_down_proj,
-                                           temp_dir, weight_dir, transpose_value_cache, max_prompt_len, group_size)
+                convert_qwen_layer(model, 0, n_splits_linear, n_splits_down_proj,
+                                   temp_dir, weight_dir, transpose_value_cache, max_prompt_len, group_size,
+                                   "prefill")
                 convert_lm_head_and_embedding(model, n_splits_linear,
                                               temp_dir, weight_dir, max_prompt_len)
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -333,7 +333,7 @@ def convert_llm(model: torch.nn.Module,
         with tempfile.TemporaryDirectory() as temp_dir:
             if save_directory is not None:
                 temp_dir = save_directory
-            temp_dir = r"D:\ruonan\qwen2.5-7B-full-weights-960"
+            temp_dir = r"D:\ruonan\qwen2-1.5B-full-weights-960"
             if os.path.exists(temp_dir):
                 import shutil
                 shutil.rmtree(temp_dir)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -150,8 +150,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     )
     rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
                                                         f"decoder_layer_{layer_idx}",
-                                                        temp_dir,
-                                                        npu_dpu_groups=6)
+                                                        temp_dir)
     bin_path = os.path.join(temp_dir, f"decoder_layer_{layer_idx}" + ".bin")
     os.remove(bin_path)
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -22,7 +22,7 @@ from .common import update_names_of_IR_and_export_blob, LLMEmbedding, LowBitLLML
 from ipex_llm.transformers.npu_models.lm_head import SlicedLMHead
 
 
-def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir):
+def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir, input_length=1):
     num_heads = model.model.layers[0].self_attn.num_heads
     head_dim = model.model.layers[0].self_attn.head_dim
     rms_norm_eps = model.config.rms_norm_eps
@@ -46,7 +46,7 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir):
         np_dtype = np.float16
 
     new_lm_head = LowBitLLMLMHead(
-        [1, 1, num_heads * head_dim],
+        [1, input_length, num_heads * head_dim],
         num_heads=num_heads,
         max_seq_len=1,  # seems doesn't matter
         rms_norm_eps=rms_norm_eps,
@@ -57,7 +57,8 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir):
         vocab_size=vocab_size,
         n_splits=n_splits_linear
     )
-    last_blob_path = update_names_of_IR_and_export_blob(new_lm_head, "lm_head", temp_dir)
+    suffix = "_prefill" if input_length > 1 else ""
+    last_blob_path = update_names_of_IR_and_export_blob(new_lm_head, f"lm_head{suffix}", temp_dir)
 
     # save weights bins files
     if not isinstance(lm_head, SlicedLMHead):
@@ -67,9 +68,10 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir):
     else:
         weight_numpy = [v.numpy() for v in weights[0]]
 
-    for idx, weight in enumerate(weight_numpy):
-        bin_file = os.path.join(weight_dir, f"model_lm_head_input_{1+idx}.bin")
-        weight.tofile(bin_file)
+    if input_length == 1:
+        for idx, weight in enumerate(weight_numpy):
+            bin_file = os.path.join(weight_dir, f"model_lm_head_input_{1+idx}.bin")
+            weight.tofile(bin_file)
 
     embedding_layer = model.model.embed_tokens
     new_embedding = LLMEmbedding(
@@ -78,8 +80,9 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir):
         embedding_weight=embedding_layer.weight.to(torch.float16).detach().numpy(),
         padding_idx=model.config.pad_token_id,
         dtype=np.float16,
+        input_length=input_length,
     )
-    first_blob_path = update_names_of_IR_and_export_blob(new_embedding, "embedding",
+    first_blob_path = update_names_of_IR_and_export_blob(new_embedding, f"embedding{suffix}",
                                                          temp_dir)
     return first_blob_path, last_blob_path
 
@@ -147,7 +150,10 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     )
     rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
                                                         f"decoder_layer_{layer_idx}",
-                                                        temp_dir)
+                                                        temp_dir,
+                                                        npu_dpu_groups=6)
+    bin_path = os.path.join(temp_dir, f"decoder_layer_{layer_idx}" + ".bin")
+    os.remove(bin_path)
 
     # 0, 1, 2 are input_embed/attention_mask/position_id
     if layernorm_const:
@@ -170,5 +176,112 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
         weight.numpy().tofile(bin_file)
         bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+5+idx*2+1}.bin")
         scale.numpy().tofile(bin_file)
+
+    del single_decoder
+
+
+def convert_qwen_prefill_layer(model, n_splits_linear, n_splits_down_proj,
+                               temp_dir, weight_dir, transpose_value_cache, kv_len, group_size):
+    layer_idx = 0
+    num_heads = model.model.layers[0].self_attn.num_heads
+    num_key_value_heads = model.model.layers[0].self_attn.num_key_value_heads
+    head_dim = model.model.layers[0].self_attn.head_dim
+    intermediate_size = model.config.intermediate_size
+    rms_norm_eps = model.config.rms_norm_eps
+
+    from ipex_llm.transformers.npu_models.qwen2_mp import LowBitQwenMultiDecoderlayer
+    curr_layer = model.model.layers[layer_idx]
+    attn_layer = curr_layer.self_attn
+    mlp_layer = curr_layer.mlp
+
+    weights = []
+    if n_splits_linear == 1:
+        for q, k, v, o, g, u in zip(attn_layer.q_proj_dq_list,
+                                    attn_layer.k_proj_dq_list,
+                                    attn_layer.v_proj_dq_list,
+                                    attn_layer.o_proj_dq_list,
+                                    mlp_layer.gate_proj_dq_list,
+                                    mlp_layer.up_proj_dq_list):
+            weights.append((q.weight, q.scale))
+            weights.append((k.weight, k.scale))
+            weights.append((v.weight, v.scale))
+            weights.append((o.weight, o.scale))
+            weights.append((g.weight, g.scale))
+            weights.append((u.weight, u.scale))
+    else:
+        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
+                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list]:
+            l_weights = []
+            scales = []
+            for l in layer_list:
+                l_weights.append(l.weight)
+                scales.append(l.scale)
+            weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+
+    if n_splits_down_proj == 1:
+        for l in mlp_layer.down_proj_dq_list:
+            weights.append((l.weight, l.scale))
+    else:
+        l_weights = []
+        scales = []
+        for l in mlp_layer.down_proj_dq_list:
+            l_weights.append(l.weight)
+            scales.append(l.scale)
+        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+
+    q_bias = attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16)
+    k_bias = attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16)
+    v_bias = attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16)
+    cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
+    cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
+    layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
+    layer_norm_1 = curr_layer.post_attention_layernorm.weight.to(torch.float16)
+
+    if isinstance(weights[0], tuple):
+        np_dtype = np.int8 if weights[0][0].dtype == torch.int8 else np.uint8
+    else:  # FP16 Linear
+        np_dtype = np.float16
+
+    single_decoder = LowBitQwenMultiDecoderlayer(
+        [1, kv_len, num_heads * head_dim],
+        input_layernorm_weights=None,
+        post_attn_layernorm_weights=None,
+        q_biases=None,
+        k_biases=None,
+        v_biases=None,
+        cached_cos=cached_cos,
+        cached_sin=cached_sin,
+        num_heads=num_heads,
+        num_key_value_heads=num_key_value_heads,
+        num_layers=1,
+        max_seq_len=kv_len,
+        rms_norm_eps=rms_norm_eps,
+        intermediate_size=intermediate_size,
+        mode="prefill",
+        transpose_value=transpose_value_cache,
+        dtype=np_dtype,
+        n_splits_linear=n_splits_linear,
+        n_splits_down_proj=n_splits_down_proj,
+        group_size=group_size
+    )
+    rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
+                                                        "decoder_layer_prefill",
+                                                        temp_dir)
+    bin_path = os.path.join(temp_dir, "decoder_layer_prefill" + ".bin")
+    os.remove(bin_path)
+
+    # 0, 1, 2 are input_embed/attention_mask/position_id
+    input_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_3.bin")
+    post_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_4.bin")
+    layer_norm_0.data.numpy().tofile(input_lm_bin_file)
+    layer_norm_1.data.numpy().tofile(post_lm_bin_file)
+    st_idx = 5
+    q_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx}.bin")
+    k_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+1}.bin")
+    v_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+2}.bin")
+    q_bias.data.numpy().tofile(q_bias_bin_file)
+    k_bias.data.numpy().tofile(k_bias_bin_file)
+    v_bias.data.numpy().tofile(v_bias_bin_file)
 
     del single_decoder

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -134,7 +134,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
         input_len = 1
         decoder_name = f"decoder_layer_{layer_idx}"
         compile = True
-        keep_ir = False
+        keep_ir = True
     else:
         input_len = kv_len
         decoder_name = "decoder_layer_prefill"

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -85,18 +85,19 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir, 
     )
     suffix = "_prefill" if input_length > 1 else ""
     compile = False if input_length > 1 else True
-    if input_length == 0:
+    if input_length == 1:
         first_blob_path = update_names_of_IR_and_export_blob(new_embedding, f"embedding{suffix}",
                                                              temp_dir, compile, keep_ir=False)
-    if input_length > 1:
+    else:
         bin_file = os.path.join(weight_dir, f"model_embedding_input_0.bin")
         embedding_layer.weight.to(torch.float16).detach().numpy().tofile(bin_file)
+        first_blob_path = None
     return first_blob_path, last_blob_path
 
 
 def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
                        temp_dir, weight_dir, transpose_value_cache, kv_len, group_size,
-                       layernorm_const):
+                       layernorm_const, mode="decode"):
     num_heads = model.model.layers[0].self_attn.num_heads
     num_key_value_heads = model.model.layers[0].self_attn.num_key_value_heads
     head_dim = model.model.layers[0].self_attn.head_dim
@@ -133,162 +134,84 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     else:  # FP16 Linear
         np_dtype = np.float16
 
-    single_decoder = LowBitQwenMultiDecoderlayer(
-        [1, 1, num_heads * head_dim],
-        input_layernorm_weights=[layer_norm_0] if layernorm_const else None,
-        post_attn_layernorm_weights=[layer_norm_1] if layernorm_const else None,
-        q_biases=None,
-        k_biases=None,
-        v_biases=None,
-        cached_cos=cached_cos,
-        cached_sin=cached_sin,
-        num_heads=num_heads,
-        num_key_value_heads=num_key_value_heads,
-        num_layers=1,
-        max_seq_len=kv_len,
-        rms_norm_eps=rms_norm_eps,
-        intermediate_size=intermediate_size,
-        mode="decode",
-        transpose_value=transpose_value_cache,
-        dtype=np_dtype,
-        n_splits_linear=n_splits_linear,
-        n_splits_down_proj=n_splits_down_proj,
-        group_size=group_size
-    )
-    rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
-                                                        f"decoder_layer_{layer_idx}",
-                                                        temp_dir)
+    if mode == "decode":
+        single_decoder = LowBitQwenMultiDecoderlayer(
+            [1, 1, num_heads * head_dim],
+            input_layernorm_weights=[layer_norm_0] if layernorm_const else None,
+            post_attn_layernorm_weights=[layer_norm_1] if layernorm_const else None,
+            q_biases=None,
+            k_biases=None,
+            v_biases=None,
+            cached_cos=cached_cos,
+            cached_sin=cached_sin,
+            num_heads=num_heads,
+            num_key_value_heads=num_key_value_heads,
+            num_layers=1,
+            max_seq_len=kv_len,
+            rms_norm_eps=rms_norm_eps,
+            intermediate_size=intermediate_size,
+            mode="decode",
+            transpose_value=transpose_value_cache,
+            dtype=np_dtype,
+            n_splits_linear=n_splits_linear,
+            n_splits_down_proj=n_splits_down_proj,
+            group_size=group_size
+        )
+    else:
+        single_decoder = LowBitQwenMultiDecoderlayer(
+            [1, kv_len, num_heads * head_dim],
+            input_layernorm_weights=None,
+            post_attn_layernorm_weights=None,
+            q_biases=None,
+            k_biases=None,
+            v_biases=None,
+            cached_cos=cached_cos,
+            cached_sin=cached_sin,
+            num_heads=num_heads,
+            num_key_value_heads=num_key_value_heads,
+            num_layers=1,
+            max_seq_len=kv_len,
+            rms_norm_eps=rms_norm_eps,
+            intermediate_size=intermediate_size,
+            mode="prefill",
+            transpose_value=transpose_value_cache,
+            dtype=np_dtype,
+            n_splits_linear=n_splits_linear,
+            n_splits_down_proj=n_splits_down_proj,
+            group_size=group_size
+        )
+    if mode == "decode":
+        rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
+                                                            f"decoder_layer_{layer_idx}",
+                                                            temp_dir)
+    else:
+        rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
+                                                            f"decoder_layer_prefill",
+                                                            temp_dir)
     bin_path = os.path.join(temp_dir, f"decoder_layer_{layer_idx}" + ".bin")
     os.remove(bin_path)
 
     # 0, 1, 2 are input_embed/attention_mask/position_id
-    if layernorm_const:
-        st_idx = 3
-    else:
-        input_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_3.bin")
-        post_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_4.bin")
-        layer_norm_0.data.numpy().tofile(input_lm_bin_file)
-        layer_norm_1.data.numpy().tofile(post_lm_bin_file)
-        st_idx = 5
-    q_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx}.bin")
-    k_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+1}.bin")
-    v_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+2}.bin")
-    q_bias.data.numpy().tofile(q_bias_bin_file)
-    k_bias.data.numpy().tofile(k_bias_bin_file)
-    v_bias.data.numpy().tofile(v_bias_bin_file)
-    # 6, 7 are past k/v
-    for idx, (weight, scale) in enumerate(weights):
-        bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+5+idx*2}.bin")
-        weight.numpy().tofile(bin_file)
-        bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+5+idx*2+1}.bin")
-        scale.numpy().tofile(bin_file)
-
-    del single_decoder
-
-
-def convert_qwen_prefill_layer(model, n_splits_linear, n_splits_down_proj,
-                               temp_dir, weight_dir, transpose_value_cache, kv_len, group_size):
-    layer_idx = 0
-    num_heads = model.model.layers[0].self_attn.num_heads
-    num_key_value_heads = model.model.layers[0].self_attn.num_key_value_heads
-    head_dim = model.model.layers[0].self_attn.head_dim
-    intermediate_size = model.config.intermediate_size
-    rms_norm_eps = model.config.rms_norm_eps
-
-    from ipex_llm.transformers.npu_models.qwen2_mp import LowBitQwenMultiDecoderlayer
-    curr_layer = model.model.layers[layer_idx]
-    attn_layer = curr_layer.self_attn
-    mlp_layer = curr_layer.mlp
-
-    weights = []
-    if n_splits_linear == 1:
-        for q, k, v, o, g, u in zip(attn_layer.q_proj_dq_list,
-                                    attn_layer.k_proj_dq_list,
-                                    attn_layer.v_proj_dq_list,
-                                    attn_layer.o_proj_dq_list,
-                                    mlp_layer.gate_proj_dq_list,
-                                    mlp_layer.up_proj_dq_list):
-            weights.append((q.weight, q.scale))
-            weights.append((k.weight, k.scale))
-            weights.append((v.weight, v.scale))
-            weights.append((o.weight, o.scale))
-            weights.append((g.weight, g.scale))
-            weights.append((u.weight, u.scale))
-    else:
-        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list]:
-            l_weights = []
-            scales = []
-            for l in layer_list:
-                l_weights.append(l.weight)
-                scales.append(l.scale)
-            weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
-
-    if n_splits_down_proj == 1:
-        for l in mlp_layer.down_proj_dq_list:
-            weights.append((l.weight, l.scale))
-    else:
-        l_weights = []
-        scales = []
-        for l in mlp_layer.down_proj_dq_list:
-            l_weights.append(l.weight)
-            scales.append(l.scale)
-        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
-
-    q_bias = attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16)
-    k_bias = attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16)
-    v_bias = attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16)
-    cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
-    cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
-    layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
-    layer_norm_1 = curr_layer.post_attention_layernorm.weight.to(torch.float16)
-
-    if isinstance(weights[0], tuple):
-        np_dtype = np.int8 if weights[0][0].dtype == torch.int8 else np.uint8
-    else:  # FP16 Linear
-        np_dtype = np.float16
-
-    single_decoder = LowBitQwenMultiDecoderlayer(
-        [1, kv_len, num_heads * head_dim],
-        input_layernorm_weights=None,
-        post_attn_layernorm_weights=None,
-        q_biases=None,
-        k_biases=None,
-        v_biases=None,
-        cached_cos=cached_cos,
-        cached_sin=cached_sin,
-        num_heads=num_heads,
-        num_key_value_heads=num_key_value_heads,
-        num_layers=1,
-        max_seq_len=kv_len,
-        rms_norm_eps=rms_norm_eps,
-        intermediate_size=intermediate_size,
-        mode="prefill",
-        transpose_value=transpose_value_cache,
-        dtype=np_dtype,
-        n_splits_linear=n_splits_linear,
-        n_splits_down_proj=n_splits_down_proj,
-        group_size=group_size
-    )
-    rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
-                                                        "decoder_layer_prefill",
-                                                        temp_dir,
-                                                        False)
-    bin_path = os.path.join(temp_dir, "decoder_layer_prefill" + ".bin")
-    os.remove(bin_path)
-
-    # 0, 1, 2 are input_embed/attention_mask/position_id
-    input_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_3.bin")
-    post_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_4.bin")
-    layer_norm_0.data.numpy().tofile(input_lm_bin_file)
-    layer_norm_1.data.numpy().tofile(post_lm_bin_file)
-    st_idx = 5
-    q_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx}.bin")
-    k_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+1}.bin")
-    v_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+2}.bin")
-    q_bias.data.numpy().tofile(q_bias_bin_file)
-    k_bias.data.numpy().tofile(k_bias_bin_file)
-    v_bias.data.numpy().tofile(v_bias_bin_file)
+    if mode == "decode":
+        if layernorm_const:
+            st_idx = 3
+        else:
+            input_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_3.bin")
+            post_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_4.bin")
+            layer_norm_0.data.numpy().tofile(input_lm_bin_file)
+            layer_norm_1.data.numpy().tofile(post_lm_bin_file)
+            st_idx = 5
+        q_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx}.bin")
+        k_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+1}.bin")
+        v_bias_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+2}.bin")
+        q_bias.data.numpy().tofile(q_bias_bin_file)
+        k_bias.data.numpy().tofile(k_bias_bin_file)
+        v_bias.data.numpy().tofile(v_bias_bin_file)
+        # 6, 7 are past k/v
+        for idx, (weight, scale) in enumerate(weights):
+            bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+5+idx*2}.bin")
+            weight.numpy().tofile(bin_file)
+            bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+5+idx*2+1}.bin")
+            scale.numpy().tofile(bin_file)
 
     del single_decoder

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -86,6 +86,9 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir, 
     )
     first_blob_path = update_names_of_IR_and_export_blob(new_embedding, f"embedding{suffix}",
                                                          temp_dir, compile)
+    if input_length > 1:
+        bin_file = os.path.join(weight_dir, f"model_embedding_input_0.bin")
+        embedding_layer.weight.to(torch.float16).detach().numpy().tofile(bin_file)
     return first_blob_path, last_blob_path
 
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -22,7 +22,8 @@ from .common import update_names_of_IR_and_export_blob, LLMEmbedding, LowBitLLML
 from ipex_llm.transformers.npu_models.lm_head import SlicedLMHead
 
 
-def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir, compile_full_model=False):
+def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir,
+                                  compile_full_model=False):
     num_heads = model.model.layers[0].self_attn.num_heads
     head_dim = model.model.layers[0].self_attn.head_dim
     rms_norm_eps = model.config.rms_norm_eps

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -84,7 +84,7 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir,
         input_length=1,
     )
     first_blob_path = update_names_of_IR_and_export_blob(new_embedding, f"embedding",
-                                                         temp_dir, True, keep_ir=False)
+                                                         temp_dir, True, keep_ir=True)
     if compile_full_model:
         bin_file = os.path.join(weight_dir, f"model_embedding_input_0.bin")
         embedding_layer.weight.to(torch.float16).detach().numpy().tofile(bin_file)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -58,7 +58,9 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir, 
         n_splits=n_splits_linear
     )
     suffix = "_prefill" if input_length > 1 else ""
-    last_blob_path = update_names_of_IR_and_export_blob(new_lm_head, f"lm_head{suffix}", temp_dir)
+    compile = False if input_length > 1 else True
+    last_blob_path = update_names_of_IR_and_export_blob(new_lm_head, f"lm_head{suffix}",
+                                                        temp_dir, compile)
 
     # save weights bins files
     if not isinstance(lm_head, SlicedLMHead):
@@ -83,7 +85,7 @@ def convert_lm_head_and_embedding(model, n_splits_linear, temp_dir, weight_dir, 
         input_length=input_length,
     )
     first_blob_path = update_names_of_IR_and_export_blob(new_embedding, f"embedding{suffix}",
-                                                         temp_dir)
+                                                         temp_dir, compile)
     return first_blob_path, last_blob_path
 
 
@@ -266,7 +268,8 @@ def convert_qwen_prefill_layer(model, n_splits_linear, n_splits_down_proj,
     )
     rest_blob_path = update_names_of_IR_and_export_blob(single_decoder,
                                                         "decoder_layer_prefill",
-                                                        temp_dir)
+                                                        temp_dir,
+                                                        False)
     bin_path = os.path.join(temp_dir, "decoder_layer_prefill" + ".bin")
     os.remove(bin_path)
 


### PR DESCRIPTION
## Description


### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/1716#issue-2628191642
To support pure c++ NPU solution, we need to provide a "compile" tool for user to save all needed files (IR / bin /  blob).

### 2. User API changes

Added two params:

- compile_full_model: if set to True, we will save prefill related IR or bin files, default to False
- save_directory: directory used to save all needed files (IR / bin /  blob), default to None

- If we just want to do inference  at python side, usage is not changed
 ```python
model = AutoModelForCausalLM.from_pretrained(model_path,
                                               optimize_model=True,
                                               pipeline=True,
                                               load_in_low_bit=args.load_in_low_bit,
                                               max_context_len=args.max_context_len,
                                               max_prompt_len=args.max_prompt_len,
                                               quantization_group_size=args.quantization_group_size,
                                               torch_dtype=torch.float16,
                                               attn_implementation="eager",
                                               transpose_value_cache=not args.disable_transpose_value_cache,
                                               mixed_precision=True,
                                               trust_remote_code=True)
```
- If we want to dump files to do further C++ inference

```python
model = AutoModelForCausalLM.from_pretrained(model_path,
                                             optimize_model=True,
                                             pipeline=True,
                                             load_in_low_bit=args.load_in_low_bit,
                                             max_context_len=args.max_context_len,
                                             max_prompt_len=args.max_prompt_len,
                                             quantization_group_size=args.quantization_group_size,
                                             torch_dtype=torch.float16,
                                             attn_implementation="eager",
                                             transpose_value_cache=not args.disable_transpose_value_cache,
                                             mixed_precision=True,
                                             trust_remote_code=True,
                                             compile_full_model=True,
                                             save_directory=save_dir)
tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
tokenizer.save_pretrained(save_dir)
```

### 3. Summary of the change 

- Added two params `compile_full_model` / `save_directory` to dump all needed files for further c++ inference support
- Sort out what files are necessary
- Code refactor

###  4. Verify correctness

- [x] Qwen2.5 7B pipeline python CW
- [x] Qwen2.5 7B pipeline c++ CW
- [x] Qwen2 1.5B pipeline python CW
- [x] Qwen2 1.5B pipeline c++ CW

**Only update qwen2 for now, can be extended to other models later.**