### PR TITLE
Support imatrix-guided quantization for NPU CW

### DIFF
--- a/python/llm/src/ipex_llm/ggml/model/llama/llama_cpp.py
+++ b/python/llm/src/ipex_llm/ggml/model/llama/llama_cpp.py
@@ -1018,6 +1018,34 @@ _lib.ggml_quantize_tensor_rtn.argtypes = [
 _lib.ggml_quantize_tensor_rtn.restype = ctypes.c_size_t
 
 
+def ggml_quantize_tensor_rtn_with_weights(
+    src,  # type: ctypes.Array[ctypes.c_float] # type: ignore
+    dst: ctypes.c_void_p,
+    scale_ptr,  # type: ctypes.Array[ctypes.c_float] # type: ignore
+    qtype: ctypes.c_int,
+    n: ctypes.c_size_t,
+    k: ctypes.c_int,
+    hist,  # type: ctypes.Array[ctypes.c_int64] # type: ignore
+    scale_search: ctypes.c_bool,
+    weights, # type: ctypes.Array[ctypes.c_float] # type: ignore
+) -> int:
+    return _lib.ggml_quantize_tensor_rtn_with_weights(src, dst, scale_ptr, qtype, n, k, hist, scale_search, weights)
+
+
+_lib.ggml_quantize_tensor_rtn_with_weights.argtypes = [
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+    ctypes.c_size_t,
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.c_int64),
+    ctypes.c_bool,
+    ctypes.POINTER(ctypes.c_float),
+]
+_lib.ggml_quantize_tensor_rtn_with_weights.restype = ctypes.c_size_t
+
+
 def ggml_type_size(qtype: ctypes.c_int) -> int:
     return _lib.ggml_type_size(qtype)
 

--- a/python/llm/src/ipex_llm/ggml/model/llama/llama_cpp.py
+++ b/python/llm/src/ipex_llm/ggml/model/llama/llama_cpp.py
@@ -1027,9 +1027,10 @@ def ggml_quantize_tensor_rtn_with_weights(
     k: ctypes.c_int,
     hist,  # type: ctypes.Array[ctypes.c_int64] # type: ignore
     scale_search: ctypes.c_bool,
-    weights, # type: ctypes.Array[ctypes.c_float] # type: ignore
+    weights,  # type: ctypes.Array[ctypes.c_float] # type: ignore
 ) -> int:
-    return _lib.ggml_quantize_tensor_rtn_with_weights(src, dst, scale_ptr, qtype, n, k, hist, scale_search, weights)
+    return _lib.ggml_quantize_tensor_rtn_with_weights(src, dst, scale_ptr, qtype, n, k,
+                                                      hist, scale_search, weights)
 
 
 _lib.ggml_quantize_tensor_rtn_with_weights.argtypes = [

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -246,8 +246,17 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
         if qtype not in [IQ2_XXS, IQ2_XS, Q2_K, IQ1_S, Q4_K, Q6_K, Q5_K, FP6_K]:
             if qtype in [SYM_INT8_RTN, SYM_INT4_RTN]:
                 scale_ptr = ctypes.cast(scale.data.data_ptr(), ctypes.POINTER(ctypes.c_float))
-                ggml.ggml_quantize_tensor_rtn(src, dst, scale_ptr, qtype, n,
-                                              k, hist, enable_scale_search)
+                if imatrix is None:
+                    ggml.ggml_quantize_tensor_rtn(src, dst, scale_ptr, qtype, n,
+                                                  k, hist, enable_scale_search)
+                else:
+                    enable_scale_search = True
+                    print("enter here")
+                    ggml.ggml_quantize_tensor_rtn_with_weights(src, dst, scale_ptr,
+                                                               qtype, n,
+                                                               k, hist,
+                                                               enable_scale_search,
+                                                               imatrix)
                 return dst_tensor, scale.type(torch.float16)
             else:
                 ggml.ggml_quantize_tensor(src, dst, qtype, n, k, hist, enable_scale_search)

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -252,6 +252,8 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
                 else:
                     enable_scale_search = True
                     print("enter here")
+                    imatrix = imatrix.data.data_ptr()
+                    imatrix = ctypes.cast(imatrix, ctypes.POINTER(ctypes.c_float))
                     ggml.ggml_quantize_tensor_rtn_with_weights(src, dst, scale_ptr,
                                                                qtype, n,
                                                                k, hist,

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -250,8 +250,6 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
                     ggml.ggml_quantize_tensor_rtn(src, dst, scale_ptr, qtype, n,
                                                   k, hist, enable_scale_search)
                 else:
-                    enable_scale_search = True
-                    print("enter here")
                     imatrix = imatrix.data.data_ptr()
                     imatrix = ctypes.cast(imatrix, ctypes.POINTER(ctypes.c_float))
                     ggml.ggml_quantize_tensor_rtn_with_weights(src, dst, scale_ptr,

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -144,10 +144,6 @@ class _BaseAutoModelClass:
         else:
             imatrix_data = None
 
-        print("imatrix data is")
-        print(imatrix_data.keys())
-        print(imatrix_data['27_down'].shape)
-
         invalidInputError(
             quantization_group_size in [0, 32, 64, 128],
             (
@@ -259,7 +255,6 @@ class _BaseAutoModelClass:
         save_directory = kwargs.pop('save_directory', None)
         fuse_layers = kwargs.pop('fuse_layers', None)
         imatrix_data = kwargs.pop('imatrix_data', None)
-        print(imatrix_data)
 
         if hasattr(model, "llm"):
             llm = model.llm
@@ -269,11 +264,8 @@ class _BaseAutoModelClass:
         with torch.no_grad():
             model.config.update({"mixed_precision": mixed_precision})
             model.config.update({"group_size": quantization_group_size})
-            print(model)
             optimize_llm_pre(model, qtype, mixed_precision,
                              quantization_group_size=quantization_group_size)
-            print(args)
-            print(kwargs)
             cls.load_convert(qtype, model, "cpu", modules_to_not_convert,
                              quantization_group_size, imatrix_data,
                              *args, **kwargs)

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -26,7 +26,7 @@ from transformers.dynamic_module_utils import get_imports
 from transformers.configuration_utils import PretrainedConfig
 
 from ipex_llm.utils.common.log4Error import invalidInputError
-from ipex_llm.transformers.utils import logger
+from ipex_llm.transformers.utils import logger, load_imatrix_data
 from ipex_llm.transformers.npu_models.convert import optimize_llm, optimize_llm_post
 
 
@@ -137,6 +137,16 @@ class _BaseAutoModelClass:
         convert_model = kwargs.pop('convert_model', False)
         save_directory = kwargs.pop('save_directory', None)
         fuse_layers = kwargs.pop('fuse_layers', None)
+        imatrix_file = kwargs.pop('imatrix_file', None)
+
+        if imatrix_file is not None:
+            imatrix_data = load_imatrix_data(imatrix_file)
+        else:
+            imatrix_data = None
+
+        print("imatrix data is")
+        print(imatrix_data.keys())
+        print(imatrix_data['27_down'].shape)
 
         invalidInputError(
             quantization_group_size in [0, 32, 64, 128],
@@ -205,7 +215,8 @@ class _BaseAutoModelClass:
                     "transpose_value_cache": transpose_value_cache,
                     "convert_model": convert_model,
                     "save_directory": save_directory,
-                    "fuse_layers": fuse_layers
+                    "fuse_layers": fuse_layers,
+                    "imatrix_data": imatrix_data
                 }
                 model = cls.optimize_npu_model(*args, **optimize_kwargs)
             else:
@@ -213,7 +224,8 @@ class _BaseAutoModelClass:
                 optimize_llm(model)
                 with torch.no_grad():
                     cls.load_convert(qtype, model, "cpu", modules_to_not_convert,
-                                     quantization_group_size, *args, **kwargs)
+                                     quantization_group_size, imatrix_data=imatrix_data,
+                                     *args, **kwargs)
                     if hasattr(model, "llm"):
                         create_npu_kernels(model.llm)
                     else:
@@ -246,6 +258,8 @@ class _BaseAutoModelClass:
         convert_model = kwargs.pop('convert_model', False)
         save_directory = kwargs.pop('save_directory', None)
         fuse_layers = kwargs.pop('fuse_layers', None)
+        imatrix_data = kwargs.pop('imatrix_data', None)
+        print(imatrix_data)
 
         if hasattr(model, "llm"):
             llm = model.llm
@@ -255,10 +269,14 @@ class _BaseAutoModelClass:
         with torch.no_grad():
             model.config.update({"mixed_precision": mixed_precision})
             model.config.update({"group_size": quantization_group_size})
+            print(model)
             optimize_llm_pre(model, qtype, mixed_precision,
                              quantization_group_size=quantization_group_size)
+            print(args)
+            print(kwargs)
             cls.load_convert(qtype, model, "cpu", modules_to_not_convert,
-                             quantization_group_size, *args, **kwargs)
+                             quantization_group_size, imatrix_data,
+                             *args, **kwargs)
             create_npu_kernels(llm)
         model = model.eval()
         logger.info(f"Finish to convert model")
@@ -305,12 +323,12 @@ class _BaseAutoModelClass:
 
     @classmethod
     def load_convert(cls, q_k, optimize_model, device, modules_to_not_convert,
-                     group_size=0, *arg, **kwarg):
+                     group_size=0, imatrix_data=None, *arg, **kwarg):
         from ipex_llm.transformers.npu_models.convert import replace_with_QuantizedLinear
 
         replace_with_QuantizedLinear(optimize_model, q_k, device=device,
                                      modules_to_not_convert=modules_to_not_convert,
-                                     group_size=group_size)
+                                     group_size=group_size, imatrix=imatrix_data)
 
     @classmethod
     def load_convert_cpu(cls, q_k, optimize_model, device, modules_to_not_convert,

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -60,7 +60,7 @@ def module_optimization(func) -> torch.nn.Module:
                     cur_imatrix = imatrix[new_module_name]
                     if cur_imatrix.shape[0] != layer.weight.shape[1]:
                         ws = layer.weight.shape[1]
-                        cur_imatrix = cur_imatrix[ws * dq_idx : ws * (dq_idx + 1)]
+                        cur_imatrix = cur_imatrix[ws * dq_idx: ws * (dq_idx + 1)]
             if name not in modules_to_not_convert:
                 new_layer = func(layer, qtype, device, modules_to_not_convert,
                                  group_size=group_size, imatrix=cur_imatrix,

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -65,7 +65,6 @@ def module_optimization(func) -> torch.nn.Module:
                     if cur_imatrix.shape[0] != layer.weight.shape[1]:
                         ws = layer.weight.shape[1]
                         cur_imatrix = cur_imatrix[ws * dq_idx : ws * (dq_idx + 1)]
-                    print(new_module_name, cur_imatrix.shape, layer.weight.shape)
             if name not in modules_to_not_convert:
                 new_layer = func(layer, qtype, device, modules_to_not_convert,
                                  group_size=group_size, imatrix=cur_imatrix,

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -19,15 +19,11 @@ import os
 import torch
 import importlib
 from ipex_llm.transformers.npu_models.linear import QuantizedLinear
-<<<<<<< HEAD
-import tempfile
 import time
 from typing import Callable, List, Optional
 from transformers import GenerationConfig, \
     LogitsProcessorList, StoppingCriteriaList
-=======
 from ipex_llm.transformers.utils import module_name_process
->>>>>>> f2eea036b1 (init commit)
 
 
 def module_optimization(func) -> torch.nn.Module:


### PR DESCRIPTION
## Description


### 1. Why the change?

work with https://github.com/intel-analytics/llm.cpp/pull/696

### 2. User API changes

- add a new parameter `imatrix_file` which default to None.
- Only when user pass imatrix_file & `set IPEX_LLM_NPU_QUANTIZATION_OPT=1`, this opt will be used.

### 3. Summary of the change 

- Initial support of imatrix-guided quantizatio for NPU CW
- Will not expose this to users, just for internal  test first

### 4. How to test?
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
