### PR TITLE
[NPU]Fix eos_token setting

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -326,7 +326,8 @@ def generate(
                       f"Generated tokens ({new_tokens}) exceed named pipeline limitation.")
 
     if "eos_token_id" not in new_generate_kwargs:
-        eos = 0xffffffff
+        generation_config = GenerationConfig.from_model_config(self.config)
+        eos = generation_config.eos_token_id
     else:
         eos = new_generate_kwargs["eos_token_id"]
     output_tokens = []

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -327,7 +327,10 @@ def generate(
 
     if "eos_token_id" not in new_generate_kwargs:
         generation_config = GenerationConfig.from_model_config(self.config)
-        eos = generation_config.eos_token_id
+        if hasattr(generation_config, "eos_token_id"):
+            eos = generation_config.eos_token_id
+        else:
+            eos = 0xffffffff
     else:
         eos = new_generate_kwargs["eos_token_id"]
     output_tokens = []


### PR DESCRIPTION
## Description

For python (cpp backend), fix `eos_token_id` setting
Now, `n_predict=256` and output is like:
![image](https://github.com/user-attachments/assets/1faac00c-ea5e-44a0-9255-64c28e12a9d1)



### 4. How to test?
- [x] Application test

