### PR TITLE
[NPU] initial support of `asym_int4_rtn`

### DIFF
--- a/python/llm/src/ipex_llm/ggml/quantize.py
+++ b/python/llm/src/ipex_llm/ggml/quantize.py
@@ -52,6 +52,7 @@ ggml_tensor_qtype = {"sym_int4": 2,   # q4_0 in ggml
                      "fp6_k": 30,
                      "sym_int4_rtn": 31,
                      "sym_int8_rtn": 32,
+                     "asym_int4_rtn": 33,
                      }
 
 # mixed precison from llama.cpp

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -84,8 +84,10 @@ Q5_K = ggml_tensor_qtype["q5_k"]
 FP6_K = ggml_tensor_qtype["fp6_k"]
 SYM_INT4_RTN = ggml_tensor_qtype["sym_int4_rtn"]
 SYM_INT8_RTN = ggml_tensor_qtype["sym_int8_rtn"]
+ASYM_INT4_RTN = ggml_tensor_qtype["asym_int4_rtn"]
 RTN_DTYPE = {
     SYM_INT4_RTN: torch.uint8,
+    ASYM_INT4_RTN: torch.uint8,
     SYM_INT8_RTN: torch.int8,
 }
 
@@ -223,12 +225,16 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
                       f"Last dim of input tensor must be multiple of {QK}")
 
     dst_size = (n // QK) * block_size_in_bytes
-    if qtype in [SYM_INT8_RTN, SYM_INT4_RTN]:
+    if qtype in [SYM_INT8_RTN, SYM_INT4_RTN, ASYM_INT4_RTN]:
         dst_tensor = torch.empty(dst_size, dtype=RTN_DTYPE[qtype],
                                  device=device)
         dst_tensor = dst_tensor.reshape(tensor.shape[0], tensor.shape[-1] // QK)
-        scale = torch.empty(n // k, dtype=torch.float32,
-                            device=device)
+        if qtype == ASYM_INT4_RTN:
+            scale = torch.empty((n // k) * 2, dtype=torch.float32,
+                                device=device)
+        else:
+            scale = torch.empty(n // k, dtype=torch.float32,
+                                device=device)
     elif qtype == NF4:
         # Deepspeed zero3 requires unified dtype,
         # thus here uses bfloat16 consistent to other layers
@@ -244,7 +250,7 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
         dst = ctypes.c_void_p(dst_tensor.data.data_ptr())
         hist = (ctypes.c_int64 * 16)()
         if qtype not in [IQ2_XXS, IQ2_XS, Q2_K, IQ1_S, Q4_K, Q6_K, Q5_K, FP6_K]:
-            if qtype in [SYM_INT8_RTN, SYM_INT4_RTN]:
+            if qtype in [SYM_INT8_RTN, SYM_INT4_RTN, ASYM_INT4_RTN]:
                 scale_ptr = ctypes.cast(scale.data.data_ptr(), ctypes.POINTER(ctypes.c_float))
                 if imatrix is None:
                     ggml.ggml_quantize_tensor_rtn(src, dst, scale_ptr, qtype, n,
@@ -269,7 +275,7 @@ def ggml_convert_qtype(tensor: torch.Tensor, qtype: int,
             ggml.ggml_quantize_tensor_with_weights(src, dst, qtype,
                                                    n // in_features, in_features,
                                                    hist, imatrix)
-    if qtype in [SYM_INT8_RTN, SYM_INT4_RTN]:
+    if qtype in [SYM_INT8_RTN, SYM_INT4_RTN, ASYM_INT4_RTN]:
         return dst_tensor, scale.type(torch.float16)
     else:
         return dst_tensor

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -284,29 +284,29 @@ class _BaseAutoModelClass:
         model.share_memory()
 
         if not pipeline:
-            if (not hasattr(model, 'llm') and
-                    model.config.model_type in ["qwen2", "llama", "minicpm"]):
-                from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
-                optimize_llm_single_process(
-                    llm,
-                    kv_len=max_context_len,
-                    max_prompt_len=max_prompt_len,
-                    transpose_value_cache=transpose_value_cache,
-                    group_size=quantization_group_size,
-                    qtype=qtype,
-                    save_directory=save_directory,
-                    fuse_layers=fuse_layers
-                )
-            else:
-                optimize_llm(
-                    llm,
-                    max_context_len=max_context_len,
-                    max_prompt_len=max_prompt_len,
-                    inter_pp=inter_pp,
-                    intra_pp=intra_pp,
-                    transpose_value_cache=transpose_value_cache,
-                    group_size=quantization_group_size
-                )
+            # if (not hasattr(model, 'llm') and
+            #         model.config.model_type in ["qwen2", "llama", "minicpm"]):
+            #     from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
+            #     optimize_llm_single_process(
+            #         llm,
+            #         kv_len=max_context_len,
+            #         max_prompt_len=max_prompt_len,
+            #         transpose_value_cache=transpose_value_cache,
+            #         group_size=quantization_group_size,
+            #         qtype=qtype,
+            #         save_directory=save_directory,
+            #         fuse_layers=fuse_layers
+            #     )
+            # else:
+            optimize_llm(
+                llm,
+                max_context_len=max_context_len,
+                max_prompt_len=max_prompt_len,
+                inter_pp=inter_pp,
+                intra_pp=intra_pp,
+                transpose_value_cache=transpose_value_cache,
+                group_size=quantization_group_size
+            )
         else:
             from ipex_llm.transformers.npu_pipeline_model.convert_pipeline \
                 import convert_llm

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -221,7 +221,7 @@ class _BaseAutoModelClass:
                 model = cls.optimize_npu_model(*args, **optimize_kwargs)
             else:
                 from ipex_llm.transformers.npu_models.convert import optimize_llm
-                optimize_llm(model)
+                # optimize_llm(model)
                 with torch.no_grad():
                     cls.load_convert(qtype, model, "cpu", modules_to_not_convert,
                                      quantization_group_size, imatrix_data,

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -284,29 +284,29 @@ class _BaseAutoModelClass:
         model.share_memory()
 
         if not pipeline:
-            # if (not hasattr(model, 'llm') and
-            #         model.config.model_type in ["qwen2", "llama", "minicpm"]):
-            #     from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
-            #     optimize_llm_single_process(
-            #         llm,
-            #         kv_len=max_context_len,
-            #         max_prompt_len=max_prompt_len,
-            #         transpose_value_cache=transpose_value_cache,
-            #         group_size=quantization_group_size,
-            #         qtype=qtype,
-            #         save_directory=save_directory,
-            #         fuse_layers=fuse_layers
-            #     )
-            # else:
-            optimize_llm(
-                llm,
-                max_context_len=max_context_len,
-                max_prompt_len=max_prompt_len,
-                inter_pp=inter_pp,
-                intra_pp=intra_pp,
-                transpose_value_cache=transpose_value_cache,
-                group_size=quantization_group_size
-            )
+            if (not hasattr(model, 'llm') and
+                    model.config.model_type in ["qwen2", "llama", "minicpm"]):
+                from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
+                optimize_llm_single_process(
+                    llm,
+                    kv_len=max_context_len,
+                    max_prompt_len=max_prompt_len,
+                    transpose_value_cache=transpose_value_cache,
+                    group_size=quantization_group_size,
+                    qtype=qtype,
+                    save_directory=save_directory,
+                    fuse_layers=fuse_layers
+                )
+            else:
+                optimize_llm(
+                    llm,
+                    max_context_len=max_context_len,
+                    max_prompt_len=max_prompt_len,
+                    inter_pp=inter_pp,
+                    intra_pp=intra_pp,
+                    transpose_value_cache=transpose_value_cache,
+                    group_size=quantization_group_size
+                )
         else:
             from ipex_llm.transformers.npu_pipeline_model.convert_pipeline \
                 import convert_llm

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -155,7 +155,7 @@ class _BaseAutoModelClass:
                 f"but got {quantization_group_size}"
             )
         )
-        
+
         if low_bit == "asym_int4":
             invalidInputError(quantization_group_size > 0,
                               "asym_int4 only support quantization_group_size == 0 for now.")

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -103,6 +103,7 @@ class _BaseAutoModelClass:
         qtype_map = {
             "sym_int4": "sym_int4_rtn",
             "sym_int8": "sym_int8_rtn",
+            "asym_int4": "asym_int4_rtn",
         }
 
         invalidInputError(

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -157,7 +157,7 @@ class _BaseAutoModelClass:
         )
 
         if low_bit == "asym_int4":
-            invalidInputError(quantization_group_size > 0,
+            invalidInputError(quantization_group_size == 0,
                               "asym_int4 only support quantization_group_size == 0 for now.")
 
         _args = copy.deepcopy(args)

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -289,29 +289,29 @@ class _BaseAutoModelClass:
         model.share_memory()
 
         if not pipeline:
-            # if (not hasattr(model, 'llm') and
-            #         model.config.model_type in ["qwen2", "llama", "minicpm"]):
-            #     from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
-            #     optimize_llm_single_process(
-            #         llm,
-            #         kv_len=max_context_len,
-            #         max_prompt_len=max_prompt_len,
-            #         transpose_value_cache=transpose_value_cache,
-            #         group_size=quantization_group_size,
-            #         qtype=qtype,
-            #         save_directory=save_directory,
-            #         fuse_layers=fuse_layers
-            #     )
-            # else:
-            optimize_llm(
-                llm,
-                max_context_len=max_context_len,
-                max_prompt_len=max_prompt_len,
-                inter_pp=inter_pp,
-                intra_pp=intra_pp,
-                transpose_value_cache=transpose_value_cache,
-                group_size=quantization_group_size
-            )
+            if (not hasattr(model, 'llm') and
+                    model.config.model_type in ["qwen2", "llama", "minicpm"]):
+                from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
+                optimize_llm_single_process(
+                    llm,
+                    kv_len=max_context_len,
+                    max_prompt_len=max_prompt_len,
+                    transpose_value_cache=transpose_value_cache,
+                    group_size=quantization_group_size,
+                    qtype=qtype,
+                    save_directory=save_directory,
+                    fuse_layers=fuse_layers
+                )
+            else:
+                optimize_llm(
+                    llm,
+                    max_context_len=max_context_len,
+                    max_prompt_len=max_prompt_len,
+                    inter_pp=inter_pp,
+                    intra_pp=intra_pp,
+                    transpose_value_cache=transpose_value_cache,
+                    group_size=quantization_group_size
+                )
         else:
             from ipex_llm.transformers.npu_pipeline_model.convert_pipeline \
                 import convert_llm

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -155,6 +155,11 @@ class _BaseAutoModelClass:
                 f"but got {quantization_group_size}"
             )
         )
+        
+        if low_bit == "asym_int4":
+            invalidInputError(quantization_group_size > 0,
+                              "asym_int4 only support quantization_group_size == 0 for now.")
+
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
 
@@ -221,7 +226,7 @@ class _BaseAutoModelClass:
                 model = cls.optimize_npu_model(*args, **optimize_kwargs)
             else:
                 from ipex_llm.transformers.npu_models.convert import optimize_llm
-                # optimize_llm(model)
+                optimize_llm(model)
                 with torch.no_grad():
                     cls.load_convert(qtype, model, "cpu", modules_to_not_convert,
                                      quantization_group_size, imatrix_data,

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -156,11 +156,6 @@ class _BaseAutoModelClass:
             )
         )
 
-        if low_bit == "asym_int4":
-            invalidInputError(quantization_group_size == 0,
-                              "asym_int4 only support quantization_group_size == 0 for now.")
-
-        _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
 
         try:

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -98,11 +98,11 @@ def replace_with_QuantizedLinear(layer, qtype, device, modules_to_not_convert,
                                              iqtype, device=device,
                                              enable_scale_search=enable_scale_search,
                                              imatrix=imatrix)
-        min = None
-        # split scale to scale & min
+        zero = None
+        # split scale to scale & zero
         if qtype == "asym_int4_rtn":
-            scale, min = torch.split(scale, scale.shape[0] // 2)
-        return QuantizedLinear(qweights, scale, min, layer.bias,
+            scale, zero = torch.split(scale, scale.shape[0] // 2)
+        return QuantizedLinear(qweights, scale, zero, layer.bias,
                                group_size=group_size, qtype=qtype)
 
 
@@ -124,11 +124,11 @@ def replace_with_DequantizedLinear(layer, qtype, device, modules_to_not_convert,
                                              iqtype, device=device,
                                              enable_scale_search=enable_scale_search,
                                              imatrix=imatrix)
-        min = None
-        # split scale to scale & min
+        zero = None
+        # split scale to scale & zero
         if qtype == "asym_int4_rtn":
-            scale, min = torch.split(scale, scale.shape[0] // 2)
-        return DequantizedLinear(qweights, scale, min, layer.bias, qtype)
+            scale, zero = torch.split(scale, scale.shape[0] // 2)
+        return DequantizedLinear(qweights, scale, zero, layer.bias, qtype)
 
 
 @module_optimization

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -115,7 +115,7 @@ def replace_with_DequantizedLinear(layer, qtype, device, modules_to_not_convert,
     from ipex_llm.ggml.quantize import ggml_tensor_qtype
     iqtype = ggml_tensor_qtype[qtype]
     if isinstance(layer, torch.nn.Linear) and not hasattr(layer, "qtype"):
-        if qtype == "sym_int4_rtn":
+        if qtype in ["sym_int4_rtn", "asym_int4_rtn"]:
             # workaround for qwen2-7B & int4
             if (layer.in_features == 3584 and layer.out_features == 152064):
                 qtype = "sym_int8_rtn"

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -88,10 +88,9 @@ def replace_with_QuantizedLinear(layer, qtype, device, modules_to_not_convert,
     from ipex_llm.ggml.quantize import ggml_tensor_qtype
     iqtype = ggml_tensor_qtype[qtype]
     if isinstance(layer, torch.nn.Linear) and not hasattr(layer, "qtype"):
-        if qtype == "sym_int4_rtn":
+        if qtype in ["sym_int4_rtn", "asym_int4_rtn"]:
             # workaround for qwen2-7B & int4
-            if (layer.in_features == 3584 and layer.out_features == 152064) or \
-               (layer.in_features == 18944 and layer.out_features == 3584):
+            if (layer.in_features == 3584 and layer.out_features == 152064):
                 qtype = "sym_int8_rtn"
                 iqtype = ggml_tensor_qtype[qtype]
         enable_scale_search = os.environ.get("IPEX_LLM_NPU_QUANTIZATION_OPT", "0") != "0"

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -99,8 +99,12 @@ def replace_with_QuantizedLinear(layer, qtype, device, modules_to_not_convert,
                                              iqtype, device=device,
                                              enable_scale_search=enable_scale_search,
                                              imatrix=imatrix)
-        return QuantizedLinear(qweights, scale, layer.bias,
-                               group_size=group_size)
+        min = None
+        # split scale to scale & min
+        if qtype == "asym_int4_rtn":
+            scale, min = torch.split(scale, scale.shape[0] // 2)
+        return QuantizedLinear(qweights, scale, min, layer.bias,
+                               group_size=group_size, qtype=qtype)
 
 
 @module_optimization
@@ -111,12 +115,21 @@ def replace_with_DequantizedLinear(layer, qtype, device, modules_to_not_convert,
     from ipex_llm.ggml.quantize import ggml_tensor_qtype
     iqtype = ggml_tensor_qtype[qtype]
     if isinstance(layer, torch.nn.Linear) and not hasattr(layer, "qtype"):
+        if qtype == "sym_int4_rtn":
+            # workaround for qwen2-7B & int4
+            if (layer.in_features == 3584 and layer.out_features == 152064):
+                qtype = "sym_int8_rtn"
+                iqtype = ggml_tensor_qtype[qtype]
         enable_scale_search = os.environ.get("IPEX_LLM_NPU_QUANTIZATION_OPT", "0") != "0"
         qweights, scale = ggml_convert_qtype(layer.weight.data.to(torch.float32),
                                              iqtype, device=device,
                                              enable_scale_search=enable_scale_search,
                                              imatrix=imatrix)
-        return DequantizedLinear(qweights, scale, layer.bias)
+        min = None
+        # split scale to scale & min
+        if qtype == "asym_int4_rtn":
+            scale, min = torch.split(scale, scale.shape[0] // 2)
+        return DequantizedLinear(qweights, scale, min, layer.bias, qtype)
 
 
 @module_optimization

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -93,6 +93,10 @@ def replace_with_QuantizedLinear(layer, qtype, device, modules_to_not_convert,
             if (layer.in_features == 3584 and layer.out_features == 152064):
                 qtype = "sym_int8_rtn"
                 iqtype = ggml_tensor_qtype[qtype]
+        if qtype == "sym_int4_rtn":
+            if (layer.in_features == 18944 and layer.out_features == 3584):
+                qtype = "sym_int8_rtn"
+                iqtype = ggml_tensor_qtype[qtype]
         enable_scale_search = os.environ.get("IPEX_LLM_NPU_QUANTIZATION_OPT", "0") != "0"
         qweights, scale = ggml_convert_qtype(layer.weight.data.to(torch.float32),
                                              iqtype, device=device,

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -181,11 +181,10 @@ def optimize_llm_pre(model: torch.nn.Module, qtype, mixed_precision,
                 # Do not split lm_head and use sym_int8 instead when mixed_precison is True
                 is_split = (not mixed_precision) and qtype in ["sym_int4_rtn", "asym_int4_rtn"]
                 split_num = 14 if is_split else 1
-                print("enter here, split num is ", split_num)
                 new_lm_head = SlicedLMHead(model.lm_head.weight, split_num=split_num,
                                            bias=model.lm_head.bias, use_split=True,
                                            group_size=quantization_group_size,
-                                           asym=(qtype == "asym_int4_rtn"))
+                                           asym=(qtype == "asym_int4_rtn") and (not mixed_precision))
             del model.lm_head
             model.lm_head = new_lm_head
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -184,7 +184,8 @@ def optimize_llm_pre(model: torch.nn.Module, qtype, mixed_precision,
                 new_lm_head = SlicedLMHead(model.lm_head.weight, split_num=split_num,
                                            bias=model.lm_head.bias, use_split=True,
                                            group_size=quantization_group_size,
-                                           asym=(qtype == "asym_int4_rtn") and (not mixed_precision))
+                                           asym=((qtype == "asym_int4_rtn") and
+                                                 (not mixed_precision)))
             del model.lm_head
             model.lm_head = new_lm_head
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -128,7 +128,7 @@ def optimize_llm_pre(model: torch.nn.Module, qtype, mixed_precision,
         from ipex_llm.transformers.npu_models.common import split_linears
         if quantization_group_size == 0:
             n_splits_linear = 1
-            if qtype == "sym_int8_rtn":
+            if qtype in ["sym_int8_rtn", "asym_int4_rtn"]:
                 # do not split mlp down_proj for Qwen2-7B & sym_int8
                 n_splits_down_proj = 1
             else:

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert_mp.py
@@ -154,18 +154,21 @@ def optimize_llm_pre(model: torch.nn.Module, qtype, mixed_precision,
                 # workaround for MiniCPM-2B
                 new_lm_head_0 = SlicedLMHead(model.lm_head_0.weight, split_num=split_num,
                                              bias=model.lm_head_0.bias, use_split=True,
-                                             group_size=quantization_group_size)
+                                             group_size=quantization_group_size,
+                                             asym=(qtype == "asym_int4_rtn"))
                 del model.lm_head_0
                 model.lm_head_0 = new_lm_head_0
                 new_lm_head_1 = SlicedLMHead(model.lm_head_1.weight, split_num=split_num,
                                              bias=model.lm_head_1.bias, use_split=True,
-                                             group_size=quantization_group_size)
+                                             group_size=quantization_group_size,
+                                             asym=(qtype == "asym_int4_rtn"))
                 del model.lm_head_1
                 model.lm_head_1 = new_lm_head_1
             else:
                 new_lm_head = SlicedLMHead(model.lm_head.weight, split_num=split_num,
                                            bias=model.lm_head.bias, use_split=True,
-                                           group_size=quantization_group_size)
+                                           group_size=quantization_group_size,
+                                           asym=(qtype == "asym_int4_rtn"))
                 del model.lm_head
                 model.lm_head = new_lm_head
 
@@ -176,11 +179,13 @@ def optimize_llm_pre(model: torch.nn.Module, qtype, mixed_precision,
             # Do not split lm_head and use sym_int8 instead when mixed_precison is True
             if quantization_group_size == 0:
                 # Do not split lm_head and use sym_int8 instead when mixed_precison is True
-                is_split = (not mixed_precision) and qtype == "sym_int4_rtn"
+                is_split = (not mixed_precision) and qtype in ["sym_int4_rtn", "asym_int4_rtn"]
                 split_num = 14 if is_split else 1
+                print("enter here, split num is ", split_num)
                 new_lm_head = SlicedLMHead(model.lm_head.weight, split_num=split_num,
                                            bias=model.lm_head.bias, use_split=True,
-                                           group_size=quantization_group_size)
+                                           group_size=quantization_group_size,
+                                           asym=(qtype == "asym_int4_rtn"))
             del model.lm_head
             model.lm_head = new_lm_head
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -129,7 +129,7 @@ class QuantizedLinear(torch.nn.Module):
         self,
         weight: torch.Tensor,
         scale: torch.Tensor,
-        min: Optional[torch.Tensor] = None,
+        zero: Optional[torch.Tensor] = None,
         bias: Optional[torch.Tensor] = None,
         qtype: Optional[str] = "sym_int4_rtn",
         group_size: int = 0,
@@ -139,7 +139,7 @@ class QuantizedLinear(torch.nn.Module):
         Args:
             weight (torch.Tensor): Linear operation weight
             scale (torch.Tensor): Quantization scale
-            min (Optional[torch.Tensor], optional): Quantization min for asym_int4_rtn
+            zero (Optional[torch.Tensor], optional): Quantization zero for asym_int4_rtn
             bias (Optional[torch.Tensor], optional): Linear operation optional bias.
                                                      Defaults to None.
             qtype (Optional[str], optional): qtype of this Linear
@@ -166,10 +166,10 @@ class QuantizedLinear(torch.nn.Module):
                 # Int4 we need to double the input channels because weights are compressed
                 self.inC *= 2
             self.scale = Parameter(scale * math.sqrt(self.inC), requires_grad=False)
-            if min is not None:
-                self.min = Parameter(min * math.sqrt(self.inC), requires_grad=False)
+            if zero is not None:
+                self.zero = Parameter(zero * math.sqrt(self.inC), requires_grad=False)
             else:
-                self.min = None
+                self.zero = None
         self.bias = bias
         self.qtype = qtype
         self.op_id = str(uuid.uuid4())
@@ -204,8 +204,8 @@ class QuantizedLinear(torch.nn.Module):
                 )
             )
 
-        min_data = self.min.data if self.min is not None else None
-        out = run_matmul(x, self.weight.data, self.scale.data, min_data, self.op_id)
+        zero_data = self.zero.data if self.zero is not None else None
+        out = run_matmul(x, self.weight.data, self.scale.data, zero_data, self.op_id)
 
         if self.bias is None:
             return out
@@ -219,7 +219,7 @@ class DequantizedLinear(torch.nn.Module):
         self,
         weight: torch.Tensor,
         scale: torch.Tensor,
-        min: Optional[torch.Tensor] = None,
+        zero: Optional[torch.Tensor] = None,
         bias: Optional[torch.Tensor] = None,
         qtype: Optional[str] = "sym_int4_rtn",
     ):
@@ -227,7 +227,7 @@ class DequantizedLinear(torch.nn.Module):
         Args:
             weight (torch.Tensor): Linear operation quantized weight
             scale (torch.Tensor): Quantization scale
-            min (Optional[torch.Tensor], optional): Quantization min for asym_int4_rtn
+            zero (Optional[torch.Tensor], optional): Quantization zero for asym_int4_rtn
             bias (Optional[torch.Tensor], optional): Linear operation optional bias.
                                                      Defaults to None.
             qtype (Optional[str], optional): qtype of this Linear
@@ -254,8 +254,8 @@ class DequantizedLinear(torch.nn.Module):
             decompressed_weight = combined_weight.view(combined_weight.size(0), -1)
             dequantized_weight = decompressed_weight.to(torch.float32) * \
                 torch.unsqueeze(scale.to(torch.float32), dim=1)
-            if qtype == "asym_int4_rtn" and min is not None:
-                dequantized_weight = dequantized_weight + torch.unsqueeze(min.to(torch.float32),
+            if qtype == "asym_int4_rtn" and zero is not None:
+                dequantized_weight = dequantized_weight + torch.unsqueeze(zero.to(torch.float32),
                                                                           dim=1)
             self.weight = Parameter(dequantized_weight, requires_grad=False).contiguous()
         else:

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -205,7 +205,6 @@ class QuantizedLinear(torch.nn.Module):
             )
 
         min_data = self.min.data if self.min is not None else None
-        print("min is None:", min is None)
         out = run_matmul(x, self.weight.data, self.scale.data, min_data, self.op_id)
 
         if self.bias is None:

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -252,8 +252,8 @@ class DequantizedLinear(torch.nn.Module):
 
             combined_weight = torch.cat((low_4bits.unsqueeze(2), high_4bits.unsqueeze(2)), dim=2)
             decompressed_weight = combined_weight.view(combined_weight.size(0), -1)
-            dequantized_weight = decompressed_weight.to(torch.float32)
-            dequantized_weight = dequantized_weight * torch.unsqueeze(scale.to(torch.float32), dim=1)
+            dequantized_weight = decompressed_weight.to(torch.float32) * \
+                torch.unsqueeze(scale.to(torch.float32), dim=1)
             if qtype == "asym_int4_rtn" and min is not None:
                 dequantized_weight = dequantized_weight + torch.unsqueeze(min.to(torch.float32),
                                                                           dim=1)

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -159,8 +159,10 @@ class QuantizedLinear(torch.nn.Module):
                 )
             )
         self.outC, self.inC = self.weight.shape
+        self.zero = None
         if group_size != 0:
             self.scale = Parameter(scale, requires_grad=False)
+            self.zero = Parameter(zero, requires_grad=False)
         else:
             if self.weight.dtype == torch.uint8:
                 # Int4 we need to double the input channels because weights are compressed
@@ -168,8 +170,6 @@ class QuantizedLinear(torch.nn.Module):
             self.scale = Parameter(scale * math.sqrt(self.inC), requires_grad=False)
             if zero is not None:
                 self.zero = Parameter(zero * math.sqrt(self.inC), requires_grad=False)
-            else:
-                self.zero = None
         self.bias = bias
         self.qtype = qtype
         self.op_id = str(uuid.uuid4())

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -252,8 +252,6 @@ class DequantizedLinear(torch.nn.Module):
 
             combined_weight = torch.cat((low_4bits.unsqueeze(2), high_4bits.unsqueeze(2)), dim=2)
             decompressed_weight = combined_weight.view(combined_weight.size(0), -1)
-            if qtype == "asym_int4_rtn":
-                decompressed_weight = decompressed_weight + 8
             dequantized_weight = decompressed_weight.to(torch.float32)
             dequantized_weight = dequantized_weight * torch.unsqueeze(scale.to(torch.float32), dim=1)
             if qtype == "asym_int4_rtn" and min is not None:

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -245,7 +245,7 @@ class DequantizedLinear(torch.nn.Module):
             )
 
         if weight.dtype == torch.uint8:
-            if qtype == "sym_int_rtn":
+            if qtype == "sym_int4_rtn":
                 weight = weight.view(torch.int8)
             high_4bits = weight >> 4
             low_4bits = (weight << 4) >> 4
@@ -255,7 +255,8 @@ class DequantizedLinear(torch.nn.Module):
             dequantized_weight = decompressed_weight.to(torch.float32) * \
                 torch.unsqueeze(scale.to(torch.float32), dim=1)
             if qtype == "asym_int4_rtn" and min is not None:
-                dequantized_weight = dequantized_weight + torch.unsqueeze(min.to(torch.float32), dim=1)
+                dequantized_weight = dequantized_weight + torch.unsqueeze(min.to(torch.float32),
+                                                                          dim=1)
             self.weight = Parameter(dequantized_weight, requires_grad=False).contiguous()
         else:
             dequantized_weight = weight.to(torch.float32) * \

--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -245,7 +245,8 @@ class DequantizedLinear(torch.nn.Module):
             )
 
         if weight.dtype == torch.uint8:
-            weight = weight.view(torch.int8)
+            if qtype == "sym_int_rtn":
+                weight = weight.view(torch.int8)
             high_4bits = weight >> 4
             low_4bits = (weight << 4) >> 4
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -585,7 +585,8 @@ class LLMBaseNNFactory(NNFactory):
                                          output_channels, input_channels,
                                          bias=bias, act_dtype=act_dtype,
                                          wt_dtype=wt_dtype, scale_factor=scale_factor,
-                                         is_prefill=is_prefill)
+                                         is_prefill=is_prefill,
+                                         asym=asym)
         self.linear_ops.append(op)
         return op
 
@@ -597,10 +598,11 @@ class LLMBaseNNFactory(NNFactory):
                         act_dtype: npt.DTypeLike = np.float16,
                         wt_dtype: npt.DTypeLike = np.float16,
                         scale_factor: bool = False,
-                        is_prefill: bool = False):
+                        is_prefill: bool = False,
+                        asym: bool = False):
         op = super().dq_split_linear(input_node, n_splits, output_channels, input_channels,
                                      False, act_dtype, wt_dtype, scale_factor,
-                                     is_prefill=is_prefill)
+                                     is_prefill=is_prefill, asym=asym)
         self.linear_ops.append(op)
         return op
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -59,9 +59,15 @@ def run_model(
     op_args_flatten = []
     for w in weights:
         if isinstance(w, tuple):  # from QuantizedLinear
-            op_args.append((set_contiguous(w[0]).numpy(), set_contiguous(w[1]).numpy()))
-            op_args_flatten.append(op_args[-1][0])
-            op_args_flatten.append(op_args[-1][1])
+            if len(w) == 2:
+                op_args.append((set_contiguous(w[0]).numpy(), set_contiguous(w[1]).numpy()))
+                op_args_flatten.append(op_args[-1][0])
+                op_args_flatten.append(op_args[-1][1])
+            else:
+                op_args.append((set_contiguous(w[0]).numpy(), set_contiguous(w[1]).numpy(), set_contiguous(w[2]).numpy()))
+                op_args_flatten.append(op_args[-1][0])
+                op_args_flatten.append(op_args[-1][1])
+                op_args_flatten.append(op_args[-1][2])
         elif w.dtype in [torch.int8, torch.uint8]:    # QuantizedLinear weight
             op_args.append(w.numpy())
             op_args_flatten.append(op_args[-1])
@@ -104,7 +110,7 @@ def run_model(
 class LLMBaseNNFactory(NNFactory):
 
     def __init__(self, max_seq_len, transpose_value, dtype, profile=False, device="NPU",
-                 n_splits_linear=1, n_splits_down_proj=1, group_size=0):
+                 n_splits_linear=1, n_splits_down_proj=1, group_size=0, asym=False):
         super().__init__(profile, device)
         self.cache_parameter_ops = []
         self.input_ops = []
@@ -117,6 +123,7 @@ class LLMBaseNNFactory(NNFactory):
         self.n_splits_linear = n_splits_linear
         self.n_splits_down_proj = n_splits_down_proj
         self.group_size = group_size
+        self.asym = asym
 
     def attention(self,
                   *,
@@ -149,7 +156,8 @@ class LLMBaseNNFactory(NNFactory):
             wt_dtype=self.dtype,
             n_splits=self.n_splits_linear,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )
 
         key_states = self.linear(
@@ -160,7 +168,8 @@ class LLMBaseNNFactory(NNFactory):
             wt_dtype=self.dtype,
             n_splits=self.n_splits_linear,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )
 
         value_states = self.linear(
@@ -171,7 +180,8 @@ class LLMBaseNNFactory(NNFactory):
             wt_dtype=self.dtype,
             n_splits=self.n_splits_linear,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )
 
         if q_bias is not None:
@@ -260,7 +270,8 @@ class LLMBaseNNFactory(NNFactory):
             attn_output, hidden_size, hidden_size, bias=False, wt_dtype=self.dtype,
             n_splits=self.n_splits_linear,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )
         return attn_output, new_key_states, new_value_states
 
@@ -428,13 +439,15 @@ class LLMBaseNNFactory(NNFactory):
             hidden_states, self.intermediate_size, self.hidden_size, bias=False,
             wt_dtype=self.dtype, n_splits=self.n_splits_linear,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )
         mm2 = self.linear(
             hidden_states, self.intermediate_size, self.hidden_size, bias=False,
             wt_dtype=self.dtype, n_splits=self.n_splits_linear,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )  # type: ignore[attr-defined]
         mm1 = self.eltwise_mul(self.swish(mm1), mm2)  # type: ignore[attr-defined]
 
@@ -442,7 +455,8 @@ class LLMBaseNNFactory(NNFactory):
             mm1, self.hidden_size, self.intermediate_size, bias=False, wt_dtype=self.dtype,
             n_splits=self.n_splits_down_proj,
             scale_factor=(self.group_size == 0),
-            is_prefill=(mode == "prefill")
+            is_prefill=(mode == "prefill"),
+            asym=self.asym
         )
         return hidden_states
 
@@ -558,11 +572,13 @@ class LLMBaseNNFactory(NNFactory):
                wt_dtype: npt.DTypeLike = np.float16,
                n_splits: int = 1,
                scale_factor: bool = True,
-               is_prefill: bool = False):
+               is_prefill: bool = False,
+               asym: bool = False):
         if n_splits == 1:
             op = super().linear(input_node, output_channels,
                                 input_channels, bias, act_dtype,
-                                wt_dtype, scale_factor=scale_factor)
+                                wt_dtype, scale_factor=scale_factor,
+                                asym=asym)
         else:
             op = super().dq_split_linear(input_node, n_splits,
                                          output_channels, input_channels,

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -64,7 +64,8 @@ def run_model(
                 op_args_flatten.append(op_args[-1][0])
                 op_args_flatten.append(op_args[-1][1])
             else:
-                op_args.append((set_contiguous(w[0]).numpy(), set_contiguous(w[1]).numpy(), set_contiguous(w[2]).numpy()))
+                op_args.append((set_contiguous(w[0]).numpy(), set_contiguous(w[1]).numpy(),
+                                set_contiguous(w[2]).numpy()))
                 op_args_flatten.append(op_args[-1][0])
                 op_args_flatten.append(op_args[-1][1])
                 op_args_flatten.append(op_args[-1][2])

--- a/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/qwen2_mp.py
@@ -601,15 +601,15 @@ def run_decode(
                            mlp_layer.down_proj_dq_list]:
             l_weights = []
             scales = []
-            mins = []
+            zeros = []
             for l in layer_list:
                 l_weights.append(l.weight)
                 scales.append(l.scale)
-                if l.min is not None:
-                    mins.append(l.min)
-            if len(mins):
+                if l.zero is not None:
+                    zeros.append(l.zero)
+            if len(zeros):
                 weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                torch.stack(mins, axis=0)))
+                                torch.stack(zeros, axis=0)))
             else:
                 weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
 
@@ -839,15 +839,15 @@ def run_prefill(
                            mlp_layer.down_proj_dq_list]:
             l_weights = []
             scales = []
-            mins = []
+            zeros = []
             for l in layer_list:
                 l_weights.append(l.weight)
                 scales.append(l.scale)
-                if l.min is not None:
-                    mins.append(l.min)
-            if len(mins):
+                if l.zero is not None:
+                    zeros.append(l.zero)
+            if len(zeros):
                 weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                torch.stack(mins, axis=0)))
+                                torch.stack(zeros, axis=0)))
             else:
                 weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -86,6 +86,7 @@ class LowBitLLMLMHead(LLMBaseNNFactory):
         device: str = "NPU",
         n_splits: int = 1,
         group_size: int = 0,
+        asym: bool = False
     ):
         super().__init__(max_seq_len=max_seq_len,
                          transpose_value=transpose_value,
@@ -119,6 +120,7 @@ class LowBitLLMLMHead(LLMBaseNNFactory):
             hidden_states, self.vocab_size, self.hidden_size, bias=False, wt_dtype=self.dtype,
             n_splits=n_splits,
             scale_factor=(group_size == 0),
+            asym=asym
         )
 
         # define outputs

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -433,7 +433,6 @@ def convert_llm_for_deploy(model: torch.nn.Module,
     if not os.path.exists(weight_dir):
         os.mkdir(weight_dir)
     layernorm_const = os.environ.get("IPEX_LLM_NPU_LAYERNORM_CONST", "1") == "1"
-    asym = getattr(model.config, "asym", False)
 
     if model.config.model_type == "qwen2":
         if group_size == 0:
@@ -457,8 +456,7 @@ def convert_llm_for_deploy(model: torch.nn.Module,
                        "weight_num": 7,
                        "weight_idx": 8,
                        "n_splits_linear": n_splits_linear,
-                       "n_splits_down_proj": n_splits_down_proj,
-                       "asym": asym}
+                       "n_splits_down_proj": n_splits_down_proj}
         model.config.update(update_dict)
         model.config.save_pretrained(save_directory)
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/convert_pipeline.py
@@ -201,7 +201,7 @@ def convert_llm(model: torch.nn.Module,
     layernorm_const = os.environ.get("IPEX_LLM_NPU_LAYERNORM_CONST", "1") == "1"
     if group_size == 0:
         n_splits_linear = 1
-        if qtype == "sym_int8_rtn":
+        if qtype in ["sym_int8_rtn", "asym_int4_rtn"]:
             # do not split mlp down_proj for Qwen2-7B & sym_int8
             n_splits_down_proj = 1
         else:
@@ -433,6 +433,7 @@ def convert_llm_for_deploy(model: torch.nn.Module,
     if not os.path.exists(weight_dir):
         os.mkdir(weight_dir)
     layernorm_const = os.environ.get("IPEX_LLM_NPU_LAYERNORM_CONST", "1") == "1"
+    asym = getattr(model.config, "asym", False)
 
     if model.config.model_type == "qwen2":
         if group_size == 0:
@@ -456,7 +457,8 @@ def convert_llm_for_deploy(model: torch.nn.Module,
                        "weight_num": 7,
                        "weight_idx": 8,
                        "n_splits_linear": n_splits_linear,
-                       "n_splits_down_proj": n_splits_down_proj}
+                       "n_splits_down_proj": n_splits_down_proj,
+                       "asym": asym}
         model.config.update(update_dict)
         model.config.save_pretrained(save_directory)
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -42,7 +42,6 @@ def convert_lm_head_and_embedding(model, temp_dir, weight_dir,
     else:
         lm_heads = lm_head.lm_heads
         asym = lm_heads[0].qtype == "asym_int4_rtn"
-        print("asym is ", asym, lm_heads[0].qtype)
         lm_head_weights = []
         scales = []
         zeros = []

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -250,9 +250,9 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
 
             weights = []
             for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                            attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                            mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                            mlp_layer.down_proj_dq_list]:
+                               attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                               mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                               mlp_layer.down_proj_dq_list]:
                 l_weights = []
                 scales = []
                 mins = []
@@ -295,14 +295,16 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
             # 6, 7 are past k/v
             if not asym:
                 for idx, (weight, scale) in enumerate(weights):
-                    bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+3+idx*2}.bin")
+                    bin_file = os.path.join(weight_dir,
+                                            f"model_{layer_idx}_input_{st_idx+3+idx*2}.bin")
                     weight.numpy().tofile(bin_file)
                     bin_file = os.path.join(weight_dir,
                                             f"model_{layer_idx}_input_{st_idx+3+idx*2+1}.bin")
                     scale.numpy().tofile(bin_file)
             else:
                 for idx, (weight, scale, m) in enumerate(weights):
-                    bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+3+idx*3}.bin")
+                    bin_file = os.path.join(weight_dir,
+                                            f"model_{layer_idx}_input_{st_idx+3+idx*3}.bin")
                     weight.numpy().tofile(bin_file)
                     bin_file = os.path.join(weight_dir,
                                             f"model_{layer_idx}_input_{st_idx+3+idx*3+1}.bin")

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -205,7 +205,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
                                         f"model_{layer_idx}_input_{st_idx+3+idx*2+1}.bin")
                 scale.numpy().tofile(bin_file)
         else:
-            for idx, (weight, scale, min) in enumerate(weights):
+            for idx, (weight, scale, m) in enumerate(weights):
                 bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+3+idx*3}.bin")
                 weight.numpy().tofile(bin_file)
                 bin_file = os.path.join(weight_dir,
@@ -213,7 +213,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
                 scale.numpy().tofile(bin_file)
                 bin_file = os.path.join(weight_dir,
                                         f"model_{layer_idx}_input_{st_idx+3+idx*3+2}.bin")
-                min.numpy().tofile(bin_file)
+                m.numpy().tofile(bin_file)
 
     del single_decoder
 
@@ -301,7 +301,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
                                             f"model_{layer_idx}_input_{st_idx+3+idx*2+1}.bin")
                     scale.numpy().tofile(bin_file)
             else:
-                for idx, (weight, scale, min) in enumerate(weights):
+                for idx, (weight, scale, m) in enumerate(weights):
                     bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+3+idx*3}.bin")
                     weight.numpy().tofile(bin_file)
                     bin_file = os.path.join(weight_dir,
@@ -309,7 +309,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
                     scale.numpy().tofile(bin_file)
                     bin_file = os.path.join(weight_dir,
                                             f"model_{layer_idx}_input_{st_idx+3+idx*3+2}.bin")
-                    min.numpy().tofile(bin_file)
+                    m.numpy().tofile(bin_file)
 
         if isinstance(weights[0], tuple):
             np_dtype = np.int8 if weights[0][0].dtype == torch.int8 else np.uint8
@@ -336,7 +336,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
             dtype=np_dtype,
             n_splits_linear=n_splits_linear,
             n_splits_down_proj=n_splits_down_proj,
-            group_size=group_size
+            group_size=group_size,
             asym=asym
         )
         update_names_of_IR_and_export_blob(fused_decoder,

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -118,15 +118,15 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
                        mlp_layer.down_proj_dq_list]:
         l_weights = []
         scales = []
-        mins = []
+        zeros = []
         for l in layer_list:
             l_weights.append(l.weight)
             scales.append(l.scale)
-            if l.min is not None:
-                mins.append(l.min)
-        if len(mins):
+            if l.zero is not None:
+                zeros.append(l.zero)
+        if len(zeros):
             weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                            torch.stack(mins, axis=0)))
+                            torch.stack(zeros, axis=0)))
         else:
             weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
 
@@ -205,7 +205,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
                                         f"model_{layer_idx}_input_{st_idx+3+idx*2+1}.bin")
                 scale.numpy().tofile(bin_file)
         else:
-            for idx, (weight, scale, m) in enumerate(weights):
+            for idx, (weight, scale, zero) in enumerate(weights):
                 bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_{st_idx+3+idx*3}.bin")
                 weight.numpy().tofile(bin_file)
                 bin_file = os.path.join(weight_dir,
@@ -213,7 +213,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
                 scale.numpy().tofile(bin_file)
                 bin_file = os.path.join(weight_dir,
                                         f"model_{layer_idx}_input_{st_idx+3+idx*3+2}.bin")
-                m.numpy().tofile(bin_file)
+                zero.numpy().tofile(bin_file)
 
     del single_decoder
 
@@ -255,15 +255,15 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
                                mlp_layer.down_proj_dq_list]:
                 l_weights = []
                 scales = []
-                mins = []
+                zeros = []
                 for l in layer_list:
                     l_weights.append(l.weight)
                     scales.append(l.scale)
-                    if l.min is not None:
-                        mins.append(l.min)
-                if len(mins):
+                    if l.zero is not None:
+                        zeros.append(l.zero)
+                if len(zeros):
                     weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                    torch.stack(mins, axis=0)))
+                                    torch.stack(zeros, axis=0)))
                 else:
                     weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
 
@@ -302,7 +302,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
                                             f"model_{layer_idx}_input_{st_idx+3+idx*2+1}.bin")
                     scale.numpy().tofile(bin_file)
             else:
-                for idx, (weight, scale, m) in enumerate(weights):
+                for idx, (weight, scale, zero) in enumerate(weights):
                     bin_file = os.path.join(weight_dir,
                                             f"model_{layer_idx}_input_{st_idx+3+idx*3}.bin")
                     weight.numpy().tofile(bin_file)
@@ -311,7 +311,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
                     scale.numpy().tofile(bin_file)
                     bin_file = os.path.join(weight_dir,
                                             f"model_{layer_idx}_input_{st_idx+3+idx*3+2}.bin")
-                    m.numpy().tofile(bin_file)
+                    zero.numpy().tofile(bin_file)
 
         if isinstance(weights[0], tuple):
             np_dtype = np.int8 if weights[0][0].dtype == torch.int8 else np.uint8


### PR DESCRIPTION
## Description

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/1766#issuecomment-2516410003
Work with https://github.com/intel-analytics/llm.cpp/pull/704 & https://github.com/intel-analytics/llm.cpp/pull/705

### 2. User API changes

New precision support of `asym_int4`

### 3. Summary of the change 

- Support new precision `asym_int4`
- Support running `asym_int4` on CPU to verify the correctness
- Support running `asym_int4` on NPU with `optimize_model=False`
- Support running `asym_int4` on NPU with `optimize_model=True` (mp version) for Qwen2-7B
- Support new convert in `convert_llm_for_deploy` for Qwen2-7B with `asym_int4` 
- Support running `asym_int4` on NPU with `optimize_model=True` (cpp version) for Qwen2-7B
- Support running `asym_int4` GW on NPU  with `optimize_model=True` (cpp version) for Qwen2-7B
- Support running `asym_int4` split LM head
- Have verified ssave & load of `asym_int4` Qwen2-7B

### 4. How to test?
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.
