### PR TITLE
Fix hf generate for llama3.2

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -455,7 +455,7 @@ def optimize_llm_single_process(
 
 def prepare_input_ids(
         self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs):
-    if isinstance(past_key_values, bool) and past_key_values:  # kvcache
+    if past_key_values and isinstance(past_key_values, bool):  # kvcache
         input_ids = input_ids[:, -1]
     else:  # prefill, reset the model here
         from .npu_llm_cpp import reset

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -455,7 +455,7 @@ def optimize_llm_single_process(
 
 def prepare_input_ids(
         self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs):
-    if past_key_values is not None:  # kvcache
+    if isinstance(past_key_values, bool) and past_key_values:  # kvcache
         input_ids = input_ids[:, -1]
     else:  # prefill, reset the model here
         from .npu_llm_cpp import reset
@@ -495,7 +495,7 @@ def causal_lm_forward(
     return CausalLMOutputWithPast(
         loss=None,
         logits=logits,
-        past_key_values=1,  # just an indicator
+        past_key_values=True,  # just an indicator
         hidden_states=None,
         attentions=None,
     )


### PR DESCRIPTION
```
-------------------- Output --------------------
<|begin_of_text|><|begin_of_text|><|start_header_id|>system<|end_header_id|>

    <|eot_id|><|start_header_id|>user<|end_header_id|>

What is AI?<|eot_id|><|start_header_id|>assistant<|end_header_id|>

Artificial Intelligence (AI) is a broad term that refers to the development of computer systems that can perform tasks that would typically require human intelligence, such as:
```

When using transformers 4.45.0, past_key_values is not None initially, but DynamicCache, the previous condition is wrong and thus not running the prefill. https://github.com/huggingface/transformers/blob/329f5dbf97a5cb2473914c88c05aa3dcb242e19a/src/transformers/generation/utils.py#L1809

@jason-dai At this moment only default hf generate settings are tested. Likely that other advanced options would have issues (e.g. some other methods need to be overridden as well).