### PR TITLE
Enable `use_batch_forward` Optimization on Battlemage GPU

### DIFF
--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -405,7 +405,7 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
             or (device in ["arc", "flex"] and qtype in [SYM_INT8, FP4])
             or (device in ["arc", "flex", "mtl"] and qtype in [FP8E4])
             or (device in ["lnl"] and qtype in [SYM_INT4] and x.shape[1] % 512 == 0)
-            or (device in ["bmg"] and qtype in [SYM_INT4])
+            or (device in ["bmg"] and qtype in [SYM_INT4, FP8E5])
         )
     return False
 

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -405,7 +405,7 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
             or (device in ["arc", "flex"] and qtype in [SYM_INT8, FP4])
             or (device in ["arc", "flex", "mtl"] and qtype in [FP8E4])
             or (device in ["lnl"] and qtype in [SYM_INT4] and x.shape[1] % 512 == 0)
-            or device in ["bmg"]
+            or (device in ["bmg"] and qtype in [SYM_INT4])
         )
     return False
 

--- a/python/llm/src/ipex_llm/transformers/low_bit_linear.py
+++ b/python/llm/src/ipex_llm/transformers/low_bit_linear.py
@@ -405,6 +405,7 @@ def use_batch_forward(x: torch.Tensor, qtype: int, output_len: int):
             or (device in ["arc", "flex"] and qtype in [SYM_INT8, FP4])
             or (device in ["arc", "flex", "mtl"] and qtype in [FP8E4])
             or (device in ["lnl"] and qtype in [SYM_INT4] and x.shape[1] % 512 == 0)
+            or device in ["bmg"]
         )
     return False
 

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -174,6 +174,8 @@ def get_xpu_device_type(x):
     name = torch.xpu.get_device_name(x.device.index)
     if name.startswith("Intel(R) Arc(TM) A"):
         return "arc"
+    if name.startswith("Intel(R) Graphics [0xe20b]"):
+        return "bmg"
     elif name.startswith("Intel(R) Arc(TM)"):
         if 'V' in name:
             return "lnl"

--- a/python/llm/src/ipex_llm/transformers/utils.py
+++ b/python/llm/src/ipex_llm/transformers/utils.py
@@ -174,7 +174,7 @@ def get_xpu_device_type(x):
     name = torch.xpu.get_device_name(x.device.index)
     if name.startswith("Intel(R) Arc(TM) A"):
         return "arc"
-    if name.startswith("Intel(R) Graphics [0xe20b]"):
+    elif name.startswith("Intel(R) Graphics [0xe20b]"):
         return "bmg"
     elif name.startswith("Intel(R) Arc(TM)"):
         if 'V' in name:


### PR DESCRIPTION
## Description: 

Enable `use_batch_forward` Optimization on Intel® Arc™ B-Series Graphics Cards (Battlemage)  
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Currently, `torch.xpu.get_device_name(0)` returns `Intel(R) Graphics [0xe20b]` on Intel® Arc™ B-Series graphics cards (code-named Battlemage), unlike the Intel® Arc™ A-Series which returns more specific names such as `Intel(R) Arc(TM) A770 Graphics`.  

This PR updates the device name matching logic to recognize `Intel(R) Graphics [0xe20b]` as an indicator for Battlemage GPUs, enabling the `use_batch_forward` optimization on these devices.  

#### Changes:  
- Extend device name matching to include `Intel(R) Graphics [0xe20b]`.  

#### Testing:  
- Validate that the optimization is correctly enabled and functions as expected on B-Series (Battlemage) GPUs.
- PR validation: https://github.com/intel-analytics/ipex-llm-workflow/actions/runs/12231715729
