### PR TITLE
support Megrez-3B-Omni and fix mask padding

### DIFF
--- a/python/llm/src/ipex_llm/transformers/models/common.py
+++ b/python/llm/src/ipex_llm/transformers/models/common.py
@@ -198,8 +198,8 @@ def prepare_mask(mask, bsz, n_heads, seq_length, kv_length, is_causal, dtype, de
         elif seq_length != kv_length and seq_length <= 32:
             mask = None
         else:
-            mask = torch.zeros([1, 1, 1, padding_kv_length], torch.finfo(dtype).min,
-                               dtype=dtype, device=device)
+            mask = torch.zeros([1, 1, 1, padding_kv_length], dtype=dtype, device=device)
+            mask[:, :, kv_length:padding_kv_length] = torch.finfo(dtype).min
             mask = mask.expand([bsz, n_heads, seq_length, padding_kv_length])
     else:
         if seq_length != kv_length and seq_length <= 32:


### PR DESCRIPTION
## Description

support Megrez-3B-Omni and fix mask padding

### 2. User API changes

use transformers 4.45

```python
from ipex_llm.transformers import AutoModelForCausalLM
model = AutoModelForCausalLM.from_pretrained(
    path,
    trust_remote_code=True,
    load_in_low_bit='sym_int4',
    modules_to_not_convert=["vision"],
    attn_implementation="eager",
)
model = model.half().eval()
model = model.to('xpu')

...

response = model.chat(
    messages,
    sampling=True,     # necessary
    use_cache=True,    # important
    max_new_tokens=MAX_NEW_TOKENS,
    # temperature=0,
)
```

