### PR TITLE
[NPU] Compatible with other third-party models like auto-round

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/linear.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/linear.py
@@ -162,7 +162,8 @@ class QuantizedLinear(torch.nn.Module):
         self.zero = None
         if group_size != 0:
             self.scale = Parameter(scale, requires_grad=False)
-            self.zero = Parameter(zero, requires_grad=False)
+            if zero is not None:
+                self.zero = Parameter(zero, requires_grad=False)
         else:
             if self.weight.dtype == torch.uint8:
                 # Int4 we need to double the input channels because weights are compressed

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -29,7 +29,6 @@ def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True
     xml_path = os.path.join(dir, model_name + ".xml")
     bin_path = os.path.join(dir, model_name + ".bin")
     model.serialize(xml_path, bin_path)
-    # model.save(xml_path)
     new_ir_path = os.path.join(dir, model_name + "_new.xml")
     new_bin_path = os.path.join(dir, model_name + "_new.bin")
     blob_path = os.path.join(dir, model_name + ".blob")
@@ -178,9 +177,9 @@ def obtain_weight_from_single_layer(attn_layer, mlp_layer):
     weights = []
     if hasattr(attn_layer, "q_proj_dq_list"):
         for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                            attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                            mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                            mlp_layer.down_proj_dq_list]:
+                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                           mlp_layer.down_proj_dq_list]:
             l_weights = []
             scales = []
             zeros = []
@@ -197,9 +196,9 @@ def obtain_weight_from_single_layer(attn_layer, mlp_layer):
                                 torch.stack(scales, axis=0)))
     else:
         for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                        attn_layer.v_proj, attn_layer.o_proj,
-                        mlp_layer.gate_proj, mlp_layer.up_proj,
-                        mlp_layer.down_proj]:
+                      attn_layer.v_proj, attn_layer.o_proj,
+                      mlp_layer.gate_proj, mlp_layer.up_proj,
+                      mlp_layer.down_proj]:
             if layer.zero is not None:
                 weights.append((layer.weight, layer.scale, layer.zero))
             else:

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/common.py
@@ -21,6 +21,7 @@ from ipex_llm.transformers.npu_models.mp_models_base import LLMBaseNNFactory
 from typing import Sequence
 from intel_npu_acceleration_library.backend.factory import NNFactory
 import numpy as np
+import torch
 
 
 def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True, keep_ir=True,
@@ -28,6 +29,7 @@ def update_names_of_IR_and_export_blob(model, model_name, dir, compile_blob=True
     xml_path = os.path.join(dir, model_name + ".xml")
     bin_path = os.path.join(dir, model_name + ".bin")
     model.serialize(xml_path, bin_path)
+    # model.save(xml_path)
     new_ir_path = os.path.join(dir, model_name + "_new.xml")
     new_bin_path = os.path.join(dir, model_name + "_new.bin")
     blob_path = os.path.join(dir, model_name + ".blob")
@@ -170,3 +172,48 @@ class LLMEmbedding(NNFactory):
 
         print("start compiling")
         self.compile()
+
+
+def obtain_weight_from_single_layer(attn_layer, mlp_layer):
+    weights = []
+    if hasattr(attn_layer, "q_proj_dq_list"):
+        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
+                            attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                            mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                            mlp_layer.down_proj_dq_list]:
+            l_weights = []
+            scales = []
+            zeros = []
+            for l in layer_list:
+                l_weights.append(l.weight)
+                scales.append(l.scale)
+                if l.zero is not None:
+                    zeros.append(l.zero)
+            if len(zeros):
+                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
+                                torch.stack(zeros, axis=0)))
+            else:
+                weights.append((torch.stack(l_weights, axis=0),
+                                torch.stack(scales, axis=0)))
+    else:
+        for layer in [attn_layer.q_proj, attn_layer.k_proj,
+                        attn_layer.v_proj, attn_layer.o_proj,
+                        mlp_layer.gate_proj, mlp_layer.up_proj,
+                        mlp_layer.down_proj]:
+            if layer.zero is not None:
+                weights.append((layer.weight, layer.scale, layer.zero))
+            else:
+                weights.append((layer.weight, layer.scale))
+    return weights
+
+
+def obtain_qkv_bias_from_single_layer(attn_layer):
+    if hasattr(attn_layer, "q_proj_dq_list"):
+        q_bias = attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16)
+        k_bias = attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16)
+        v_bias = attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16)
+    else:
+        q_bias = attn_layer.q_proj.bias.to(torch.float16)
+        k_bias = attn_layer.k_proj.bias.to(torch.float16)
+        v_bias = attn_layer.v_proj.bias.to(torch.float16)
+    return q_bias, k_bias, v_bias

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
@@ -410,13 +410,6 @@ def convert_fused_llama_layer(model, fused_layers, n_splits_linear, n_splits_dow
         input_layer_norm_weights = []
         post_attn_layernorm_weights = []
         layer_indexs = range(layer_start, layer_end)
-        if hasattr(model.model.layers[0].mlp, "gate_proj_dq_list"):
-            n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
-            n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
-        else:
-            # TODO: may need update
-            n_splits_linear = 1
-            n_splits_down_proj = 1
         for layer_idx in layer_indexs:
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
@@ -433,12 +433,13 @@ def convert_fused_llama_layer(model, fused_layers, n_splits_linear, n_splits_dow
                         weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
                                         torch.stack(zeros, axis=0)))
                     else:
-                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+                        weights.append((torch.stack(l_weights, axis=0),
+                                        torch.stack(scales, axis=0)))
             else:
                 for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                            attn_layer.v_proj, attn_layer.o_proj,
-                            mlp_layer.gate_proj, mlp_layer.up_proj,
-                            mlp_layer.down_proj]:
+                              attn_layer.v_proj, attn_layer.o_proj,
+                              mlp_layer.gate_proj, mlp_layer.up_proj,
+                              mlp_layer.down_proj]:
                     if layer.zero is not None:
                         weights.append((layer.weight, layer.scale, layer.zero))
                     else:

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
@@ -18,7 +18,8 @@
 import torch
 import numpy as np
 import os
-from .common import update_names_of_IR_and_export_blob, LLMEmbedding, LowBitLLMLMHead
+from .common import update_names_of_IR_and_export_blob, LLMEmbedding, LowBitLLMLMHead, \
+    obtain_weight_from_single_layer
 from intel_npu_acceleration_library.backend.factory import NNFactory
 
 
@@ -261,36 +262,7 @@ def convert_llama_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     curr_layer = model.model.layers[layer_idx]
     attn_layer = curr_layer.self_attn
     mlp_layer = curr_layer.mlp
-
-    weights = []
-    if hasattr(attn_layer, "q_proj_dq_list"):
-        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                           mlp_layer.down_proj_dq_list]:
-            l_weights = []
-            scales = []
-            zeros = []
-            for l in layer_list:
-                l_weights.append(l.weight)
-                scales.append(l.scale)
-                if l.zero is not None:
-                    zeros.append(l.zero)
-            if len(zeros):
-                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                torch.stack(zeros, axis=0)))
-            else:
-                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
-    else:
-        for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                      attn_layer.v_proj, attn_layer.o_proj,
-                      mlp_layer.gate_proj, mlp_layer.up_proj,
-                      mlp_layer.down_proj]:
-            if layer.zero is not None:
-                weights.append((layer.weight, layer.scale, layer.zero))
-            else:
-                weights.append((layer.weight, layer.scale))
-
+    weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
     if hasattr(curr_layer.self_attn.rotary_emb, "cos_cached"):
         # llama-2-7B & llama-3-8B
         cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
@@ -414,37 +386,7 @@ def convert_fused_llama_layer(model, fused_layers, n_splits_linear, n_splits_dow
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn
             mlp_layer = curr_layer.mlp
-
-            weights = []
-            if hasattr(attn_layer, "q_proj_dq_list"):
-                for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                                   attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                                   mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                                   mlp_layer.down_proj_dq_list]:
-                    l_weights = []
-                    scales = []
-                    zeros = []
-                    for l in layer_list:
-                        l_weights.append(l.weight)
-                        scales.append(l.scale)
-                        if l.zero is not None:
-                            zeros.append(l.zero)
-                    if len(zeros):
-                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                        torch.stack(zeros, axis=0)))
-                    else:
-                        weights.append((torch.stack(l_weights, axis=0),
-                                        torch.stack(scales, axis=0)))
-            else:
-                for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                              attn_layer.v_proj, attn_layer.o_proj,
-                              mlp_layer.gate_proj, mlp_layer.up_proj,
-                              mlp_layer.down_proj]:
-                    if layer.zero is not None:
-                        weights.append((layer.weight, layer.scale, layer.zero))
-                    else:
-                        weights.append((layer.weight, layer.scale))
-
+            weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
             if hasattr(curr_layer.self_attn.rotary_emb, "cos_cached"):
                 # llama-2-7B & llama-3-8B
                 cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/llama.py
@@ -263,23 +263,33 @@ def convert_llama_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     mlp_layer = curr_layer.mlp
 
     weights = []
-    for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                       attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                       mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                       mlp_layer.down_proj_dq_list]:
-        l_weights = []
-        scales = []
-        zeros = []
-        for l in layer_list:
-            l_weights.append(l.weight)
-            scales.append(l.scale)
-            if l.zero is not None:
-                zeros.append(l.zero)
-        if len(zeros):
-            weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                            torch.stack(zeros, axis=0)))
-        else:
-            weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+    if hasattr(attn_layer, "q_proj_dq_list"):
+        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
+                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                           mlp_layer.down_proj_dq_list]:
+            l_weights = []
+            scales = []
+            zeros = []
+            for l in layer_list:
+                l_weights.append(l.weight)
+                scales.append(l.scale)
+                if l.zero is not None:
+                    zeros.append(l.zero)
+            if len(zeros):
+                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
+                                torch.stack(zeros, axis=0)))
+            else:
+                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+    else:
+        for layer in [attn_layer.q_proj, attn_layer.k_proj,
+                      attn_layer.v_proj, attn_layer.o_proj,
+                      mlp_layer.gate_proj, mlp_layer.up_proj,
+                      mlp_layer.down_proj]:
+            if layer.zero is not None:
+                weights.append((layer.weight, layer.scale, layer.zero))
+            else:
+                weights.append((layer.weight, layer.scale))
 
     if hasattr(curr_layer.self_attn.rotary_emb, "cos_cached"):
         # llama-2-7B & llama-3-8B
@@ -400,31 +410,46 @@ def convert_fused_llama_layer(model, fused_layers, n_splits_linear, n_splits_dow
         input_layer_norm_weights = []
         post_attn_layernorm_weights = []
         layer_indexs = range(layer_start, layer_end)
-        n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
-        n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
+        if hasattr(model.model.layers[0].mlp, "gate_proj_dq_list"):
+            n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
+            n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
+        else:
+            # TODO: may need update
+            n_splits_linear = 1
+            n_splits_down_proj = 1
         for layer_idx in layer_indexs:
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn
             mlp_layer = curr_layer.mlp
 
             weights = []
-            for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                               attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                               mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                               mlp_layer.down_proj_dq_list]:
-                l_weights = []
-                scales = []
-                zeros = []
-                for l in layer_list:
-                    l_weights.append(l.weight)
-                    scales.append(l.scale)
-                    if l.zero is not None:
-                        zeros.append(l.zero)
-                if len(zeros):
-                    weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                    torch.stack(zeros, axis=0)))
-                else:
-                    weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+            if hasattr(attn_layer, "q_proj_dq_list"):
+                for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
+                                   attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                                   mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                                   mlp_layer.down_proj_dq_list]:
+                    l_weights = []
+                    scales = []
+                    zeros = []
+                    for l in layer_list:
+                        l_weights.append(l.weight)
+                        scales.append(l.scale)
+                        if l.zero is not None:
+                            zeros.append(l.zero)
+                    if len(zeros):
+                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
+                                        torch.stack(zeros, axis=0)))
+                    else:
+                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+            else:
+                for layer in [attn_layer.q_proj, attn_layer.k_proj,
+                            attn_layer.v_proj, attn_layer.o_proj,
+                            mlp_layer.gate_proj, mlp_layer.up_proj,
+                            mlp_layer.down_proj]:
+                    if layer.zero is not None:
+                        weights.append((layer.weight, layer.scale, layer.zero))
+                    else:
+                        weights.append((layer.weight, layer.scale))
 
             if hasattr(curr_layer.self_attn.rotary_emb, "cos_cached"):
                 # llama-2-7B & llama-3-8B

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
@@ -18,7 +18,7 @@
 import torch
 import numpy as np
 import os
-from .common import update_names_of_IR_and_export_blob
+from .common import update_names_of_IR_and_export_blob, obtain_weight_from_single_layer
 from intel_npu_acceleration_library.backend.factory import NNFactory
 from ipex_llm.transformers.npu_models.mp_models_base import LLMBaseNNFactory
 from typing import Sequence
@@ -309,36 +309,7 @@ def convert_minicpm_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     curr_layer = model.model.layers[layer_idx]
     attn_layer = curr_layer.self_attn
     mlp_layer = curr_layer.mlp
-
-    weights = []
-    if hasattr(attn_layer, "q_proj_dq_list"):
-        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                           mlp_layer.down_proj_dq_list]:
-            l_weights = []
-            scales = []
-            zeros = []
-            for l in layer_list:
-                l_weights.append(l.weight)
-                scales.append(l.scale)
-                if l.zero is not None:
-                    zeros.append(l.zero)
-            if len(zeros):
-                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                torch.stack(zeros, axis=0)))
-            else:
-                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
-    else:
-        for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                      attn_layer.v_proj, attn_layer.o_proj,
-                      mlp_layer.gate_proj, mlp_layer.up_proj,
-                      mlp_layer.down_proj]:
-            if layer.zero is not None:
-                weights.append((layer.weight, layer.scale, layer.zero))
-            else:
-                weights.append((layer.weight, layer.scale))
-
+    weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
     cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
     cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
     layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
@@ -439,37 +410,7 @@ def convert_fused_minicpm_layer(model, fused_layers, n_splits_linear, n_splits_d
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn
             mlp_layer = curr_layer.mlp
-
-            weights = []
-            if hasattr(attn_layer, "q_proj_dq_list"):
-                for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                                   attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                                   mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                                   mlp_layer.down_proj_dq_list]:
-                    l_weights = []
-                    scales = []
-                    zeros = []
-                    for l in layer_list:
-                        l_weights.append(l.weight)
-                        scales.append(l.scale)
-                        if l.zero is not None:
-                            zeros.append(l.zero)
-                    if len(zeros):
-                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                        torch.stack(zeros, axis=0)))
-                    else:
-                        weights.append((torch.stack(l_weights, axis=0),
-                                        torch.stack(scales, axis=0)))
-            else:
-                for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                              attn_layer.v_proj, attn_layer.o_proj,
-                              mlp_layer.gate_proj, mlp_layer.up_proj,
-                              mlp_layer.down_proj]:
-                    if layer.zero is not None:
-                        weights.append((layer.weight, layer.scale, layer.zero))
-                    else:
-                        weights.append((layer.weight, layer.scale))
-
+            weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
             cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
             cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
             layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
@@ -458,7 +458,8 @@ def convert_fused_minicpm_layer(model, fused_layers, n_splits_linear, n_splits_d
                         weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
                                         torch.stack(zeros, axis=0)))
                     else:
-                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+                        weights.append((torch.stack(l_weights, axis=0),
+                                        torch.stack(scales, axis=0)))
             else:
                 for layer in [attn_layer.q_proj, attn_layer.k_proj,
                               attn_layer.v_proj, attn_layer.o_proj,

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/minicpm.py
@@ -435,8 +435,6 @@ def convert_fused_minicpm_layer(model, fused_layers, n_splits_linear, n_splits_d
         input_layer_norm_weights = []
         post_attn_layernorm_weights = []
         layer_indexs = range(layer_start, layer_end)
-        n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
-        n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
         for layer_idx in layer_indexs:
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -278,13 +278,6 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
         k_biases = []
         v_biases = []
         layer_indexs = range(layer_start, layer_end)
-        if hasattr(model.model.layers[0].mlp, "gate_proj_dq_list"):
-            n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
-            n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
-        else:
-            # TODO: may need update
-            n_splits_linear = 1
-            n_splits_down_proj = 1
         for layer_idx in layer_indexs:
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -134,7 +134,7 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     attn_layer = curr_layer.self_attn
     mlp_layer = curr_layer.mlp
     weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
-    q_bias, k_bias, v_bias = obtain_qkv_bias_from_single_layer
+    q_bias, k_bias, v_bias = obtain_qkv_bias_from_single_layer(attn_layer)
     cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
     cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
     layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
@@ -256,7 +256,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
             layer_weights.extend(weights)
             input_layer_norm_weights.append(layer_norm_0)
             post_attn_layernorm_weights.append(layer_norm_1)
-            q_bias, k_bias, v_bias = obtain_qkv_bias_from_single_layer
+            q_bias, k_bias, v_bias = obtain_qkv_bias_from_single_layer(attn_layer)
             q_biases.append(q_bias)
             k_biases.append(k_bias)
             v_biases.append(v_bias)

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -18,7 +18,8 @@
 import torch
 import numpy as np
 import os
-from .common import update_names_of_IR_and_export_blob, LLMEmbedding, LowBitLLMLMHead
+from .common import update_names_of_IR_and_export_blob, LLMEmbedding, LowBitLLMLMHead, \
+    obtain_weight_from_single_layer, obtain_qkv_bias_from_single_layer
 from ipex_llm.transformers.npu_models.lm_head import SlicedLMHead
 
 
@@ -132,44 +133,8 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     curr_layer = model.model.layers[layer_idx]
     attn_layer = curr_layer.self_attn
     mlp_layer = curr_layer.mlp
-
-    weights = []
-    if hasattr(attn_layer, "q_proj_dq_list"):
-        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                           mlp_layer.down_proj_dq_list]:
-            l_weights = []
-            scales = []
-            zeros = []
-            for l in layer_list:
-                l_weights.append(l.weight)
-                scales.append(l.scale)
-                if l.zero is not None:
-                    zeros.append(l.zero)
-            if len(zeros):
-                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                torch.stack(zeros, axis=0)))
-            else:
-                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
-    else:
-        for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                      attn_layer.v_proj, attn_layer.o_proj,
-                      mlp_layer.gate_proj, mlp_layer.up_proj,
-                      mlp_layer.down_proj]:
-            if layer.zero is not None:
-                weights.append((layer.weight, layer.scale, layer.zero))
-            else:
-                weights.append((layer.weight, layer.scale))
-
-    if hasattr(attn_layer, "q_proj_dq_list"):
-        q_bias = attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16)
-        k_bias = attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16)
-        v_bias = attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16)
-    else:
-        q_bias = attn_layer.q_proj.bias.to(torch.float16)
-        k_bias = attn_layer.k_proj.bias.to(torch.float16)
-        v_bias = attn_layer.v_proj.bias.to(torch.float16)
+    weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
+    q_bias, k_bias, v_bias = obtain_qkv_bias_from_single_layer
     cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
     cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
     layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
@@ -282,37 +247,7 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn
             mlp_layer = curr_layer.mlp
-
-            weights = []
-            if hasattr(attn_layer, "q_proj_dq_list"):
-                for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                                   attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                                   mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                                   mlp_layer.down_proj_dq_list]:
-                    l_weights = []
-                    scales = []
-                    zeros = []
-                    for l in layer_list:
-                        l_weights.append(l.weight)
-                        scales.append(l.scale)
-                        if l.zero is not None:
-                            zeros.append(l.zero)
-                    if len(zeros):
-                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                        torch.stack(zeros, axis=0)))
-                    else:
-                        weights.append((torch.stack(l_weights, axis=0),
-                                        torch.stack(scales, axis=0)))
-            else:
-                for layer in [attn_layer.q_proj, attn_layer.k_proj,
-                              attn_layer.v_proj, attn_layer.o_proj,
-                              mlp_layer.gate_proj, mlp_layer.up_proj,
-                              mlp_layer.down_proj]:
-                    if layer.zero is not None:
-                        weights.append((layer.weight, layer.scale, layer.zero))
-                    else:
-                        weights.append((layer.weight, layer.scale))
-
+            weights = obtain_weight_from_single_layer(attn_layer, mlp_layer)
             cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
             cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
             layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
@@ -321,14 +256,10 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
             layer_weights.extend(weights)
             input_layer_norm_weights.append(layer_norm_0)
             post_attn_layernorm_weights.append(layer_norm_1)
-            if hasattr(attn_layer, "q_proj_dq_list"):
-                q_biases.append(attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16))
-                k_biases.append(attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16))
-                v_biases.append(attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16))
-            else:
-                q_biases.append(attn_layer.q_proj.bias.to(torch.float16))
-                k_biases.append(attn_layer.k_proj.bias.to(torch.float16))
-                v_biases.append(attn_layer.v_proj.bias.to(torch.float16))
+            q_bias, k_bias, v_bias = obtain_qkv_bias_from_single_layer
+            q_biases.append(q_bias)
+            k_biases.append(k_bias)
+            v_biases.append(v_bias)
 
             # save weight
             input_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_3.bin")

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -134,27 +134,42 @@ def convert_qwen_layer(model, layer_idx, n_splits_linear, n_splits_down_proj,
     mlp_layer = curr_layer.mlp
 
     weights = []
-    for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                       attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                       mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                       mlp_layer.down_proj_dq_list]:
-        l_weights = []
-        scales = []
-        zeros = []
-        for l in layer_list:
-            l_weights.append(l.weight)
-            scales.append(l.scale)
-            if l.zero is not None:
-                zeros.append(l.zero)
-        if len(zeros):
-            weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                            torch.stack(zeros, axis=0)))
-        else:
-            weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+    if hasattr(attn_layer, "q_proj_dq_list"):
+        for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
+                           attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                           mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                           mlp_layer.down_proj_dq_list]:
+            l_weights = []
+            scales = []
+            zeros = []
+            for l in layer_list:
+                l_weights.append(l.weight)
+                scales.append(l.scale)
+                if l.zero is not None:
+                    zeros.append(l.zero)
+            if len(zeros):
+                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
+                                torch.stack(zeros, axis=0)))
+            else:
+                weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+    else:
+        for layer in [attn_layer.q_proj, attn_layer.k_proj,
+                      attn_layer.v_proj, attn_layer.o_proj,
+                      mlp_layer.gate_proj, mlp_layer.up_proj,
+                      mlp_layer.down_proj]:
+            if layer.zero is not None:
+                weights.append((layer.weight, layer.scale, layer.zero))
+            else:
+                weights.append((layer.weight, layer.scale))
 
-    q_bias = attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16)
-    k_bias = attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16)
-    v_bias = attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16)
+    if hasattr(attn_layer, "q_proj_dq_list"):
+        q_bias = attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16)
+        k_bias = attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16)
+        v_bias = attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16)
+    else:
+        q_bias = attn_layer.q_proj.bias.to(torch.float16)
+        k_bias = attn_layer.k_proj.bias.to(torch.float16)
+        v_bias = attn_layer.v_proj.bias.to(torch.float16)
     cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
     cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
     layer_norm_0 = curr_layer.input_layernorm.weight.to(torch.float16)
@@ -263,31 +278,47 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
         k_biases = []
         v_biases = []
         layer_indexs = range(layer_start, layer_end)
-        n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
-        n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
+        if hasattr(model.model.layers[0].mlp, "gate_proj_dq_list"):
+            n_splits_linear = len(model.model.layers[0].mlp.gate_proj_dq_list)
+            n_splits_down_proj = len(model.model.layers[0].mlp.down_proj_dq_list)
+        else:
+            # TODO: may need update
+            n_splits_linear = 1
+            n_splits_down_proj = 1
         for layer_idx in layer_indexs:
             curr_layer = model.model.layers[layer_idx]
             attn_layer = curr_layer.self_attn
             mlp_layer = curr_layer.mlp
 
             weights = []
-            for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
-                               attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
-                               mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
-                               mlp_layer.down_proj_dq_list]:
-                l_weights = []
-                scales = []
-                zeros = []
-                for l in layer_list:
-                    l_weights.append(l.weight)
-                    scales.append(l.scale)
-                    if l.zero is not None:
-                        zeros.append(l.zero)
-                if len(zeros):
-                    weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
-                                    torch.stack(zeros, axis=0)))
-                else:
-                    weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0)))
+            if hasattr(attn_layer, "q_proj_dq_list"):
+                for layer_list in [attn_layer.q_proj_dq_list, attn_layer.k_proj_dq_list,
+                                   attn_layer.v_proj_dq_list, attn_layer.o_proj_dq_list,
+                                   mlp_layer.gate_proj_dq_list, mlp_layer.up_proj_dq_list,
+                                   mlp_layer.down_proj_dq_list]:
+                    l_weights = []
+                    scales = []
+                    zeros = []
+                    for l in layer_list:
+                        l_weights.append(l.weight)
+                        scales.append(l.scale)
+                        if l.zero is not None:
+                            zeros.append(l.zero)
+                    if len(zeros):
+                        weights.append((torch.stack(l_weights, axis=0), torch.stack(scales, axis=0),
+                                        torch.stack(zeros, axis=0)))
+                    else:
+                        weights.append((torch.stack(l_weights, axis=0),
+                                        torch.stack(scales, axis=0)))
+            else:
+                for layer in [attn_layer.q_proj, attn_layer.k_proj,
+                              attn_layer.v_proj, attn_layer.o_proj,
+                              mlp_layer.gate_proj, mlp_layer.up_proj,
+                              mlp_layer.down_proj]:
+                    if layer.zero is not None:
+                        weights.append((layer.weight, layer.scale, layer.zero))
+                    else:
+                        weights.append((layer.weight, layer.scale))
 
             cached_cos = curr_layer.self_attn.rotary_emb.cos_cached.to(torch.float16)
             cached_sin = curr_layer.self_attn.rotary_emb.sin_cached.to(torch.float16)
@@ -297,9 +328,14 @@ def convert_fused_qwen_layer(model, fused_layers, n_splits_linear, n_splits_down
             layer_weights.extend(weights)
             input_layer_norm_weights.append(layer_norm_0)
             post_attn_layernorm_weights.append(layer_norm_1)
-            q_biases.append(attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16))
-            k_biases.append(attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16))
-            v_biases.append(attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16))
+            if hasattr(attn_layer, "q_proj_dq_list"):
+                q_biases.append(attn_layer.q_proj_dq_list.q_proj_dq_0.bias.to(torch.float16))
+                k_biases.append(attn_layer.k_proj_dq_list.k_proj_dq_0.bias.to(torch.float16))
+                v_biases.append(attn_layer.v_proj_dq_list.v_proj_dq_0.bias.to(torch.float16))
+            else:
+                q_biases.append(attn_layer.q_proj.bias.to(torch.float16))
+                k_biases.append(attn_layer.k_proj.bias.to(torch.float16))
+                v_biases.append(attn_layer.v_proj.bias.to(torch.float16))
 
             # save weight
             input_lm_bin_file = os.path.join(weight_dir, f"model_{layer_idx}_input_3.bin")


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Port from https://github.com/intel-analytics/ipex-llm/pull/12581.
When we  convert other third-party models to our NPU model, take auto-round for example, I will directly convert their `QuantLinear` to our `QuantizedLinear` and will not call `split_linears` in this progress.
So linear of model converted from auto-round will not have `_dq_list` suffix.

### 2. User API changes

No change.

### 3. Summary of the change 

- update our code to be compatible with other third-party models like auto-round
- simplify code
- fix GW sym  int4 runtime error
- code refactor

### 4. How to test?
- [ ] N/A
- [ ] Unit test: Please manually trigger the PR Validation [here](https://github.com/intel-analytics/ipex-llm-workflow/actions/workflows/llm-PR-validation.yml) by inputting the PR number (e.g., `1234`). And paste your action link here once it has been successfully finished.

