### PR TITLE
[NPU] Fix regression caused by layer_norm change

### DIFF
--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -477,7 +477,6 @@ class LLMBaseNNFactory(NNFactory):
             hidden_states = self.convert_to_fp16(hidden_states)
         else:
             layernorm_weight = self.convert_to_fp32(layernorm_weight)
-        hidden_states = self.convert_to_fp16(hidden_states)
         hidden_states = self.eltwise_mul(layernorm_weight, hidden_states)
         hidden_states = self.convert_to_fp16(hidden_states)
         return hidden_states

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -472,7 +472,7 @@ class LLMBaseNNFactory(NNFactory):
         )
         eps = self.constant(self.rms_norm_eps)
         hidden_states = self.eltwise_div(hidden_states, self.sqrt(self.eltwise_add(variance, eps)))
-        if os.environ.get("IPEX_LLM_NPU_DRIVER_VERSION", "0") == "1":
+        if os.environ.get("IPEX_LLM_NPU_DRIVER_VERSION", None) in ["5716", "5733"]:
             # to support special drivers
             hidden_states = self.convert_to_fp16(hidden_states)
         else:

--- a/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/mp_models_base.py
@@ -472,6 +472,11 @@ class LLMBaseNNFactory(NNFactory):
         )
         eps = self.constant(self.rms_norm_eps)
         hidden_states = self.eltwise_div(hidden_states, self.sqrt(self.eltwise_add(variance, eps)))
+        if os.environ.get("IPEX_LLM_NPU_DRIVER_VERSION", "0") == "1":
+            # to support special drivers
+            hidden_states = self.convert_to_fp16(hidden_states)
+        else:
+            layernorm_weight = self.convert_to_fp32(layernorm_weight)
         hidden_states = self.convert_to_fp16(hidden_states)
         hidden_states = self.eltwise_mul(layernorm_weight, hidden_states)
         hidden_states = self.convert_to_fp16(hidden_states)


### PR DESCRIPTION
## Description

Background: https://github.com/analytics-zoo/nano/issues/1798

Add a new env `IPEX_LLM_NPU_DRIVER_VERSION`:

- For default setting, revert layernorm graph to fix perf regression.
- To support special driver (such as 5716 driver), need to `set IPEX_LLM_NPU_DRIVER_VERSION=5716` manually.

### 4. How to test?
- [x] Application test
