### PR TITLE
[NPU] Support minicpm-v with python cpp backend

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/run.py
+++ b/python/llm/dev/benchmark/all-in-one/run.py
@@ -650,7 +650,7 @@ def transformers_int4_npu_win(repo_id,
     load_time = end - st
     print(">> loading of model costs {}s".format(load_time))
 
-    if not hasattr(model, "model_ptr"):
+    if not hasattr(model, "model_ptr") or repo_id in MINICPM_V_IDS:
         model = BenchmarkWrapper(model)
 
     result = {}

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/CPP_Examples/llm-npu-cli.cpp
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/CPP_Examples/llm-npu-cli.cpp
@@ -102,7 +102,7 @@ std::string run_generate(void* void_model, int32_t* embd_inp_ptr, int32_t embd_i
                          npu_model_params model_params, tokenizer_params tok_params, npu_generation_params generation_params, bool do_print){
     auto start = std::chrono::high_resolution_clock::now();
     float* logits = run_prefill(void_model, embd_inp_ptr, embd_inp_size,
-                                generation_params.repetition_penalty, false);
+                                generation_params.repetition_penalty);
     int32_t token = llm_sample_token(logits, true, model_params.vocab_size);
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);

--- a/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/CPP_Examples/llm-npu-cli.cpp
+++ b/python/llm/example/NPU/HF-Transformers-AutoModels/LLM/CPP_Examples/llm-npu-cli.cpp
@@ -102,7 +102,7 @@ std::string run_generate(void* void_model, int32_t* embd_inp_ptr, int32_t embd_i
                          npu_model_params model_params, tokenizer_params tok_params, npu_generation_params generation_params, bool do_print){
     auto start = std::chrono::high_resolution_clock::now();
     float* logits = run_prefill(void_model, embd_inp_ptr, embd_inp_size,
-                                generation_params.repetition_penalty);
+                                generation_params.repetition_penalty, false);
     int32_t token = llm_sample_token(logits, true, model_params.vocab_size);
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -302,8 +302,6 @@ class _BaseAutoModelClass:
         model.share_memory()
 
         if not pipeline:
-            # if (not hasattr(model, 'llm') and
-            #         model.config.model_type in ["qwen2", "llama", "minicpm"]):
             if model.config.model_type in ["qwen2", "llama", "minicpm"]:
                 from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
                 optimize_llm_single_process(

--- a/python/llm/src/ipex_llm/transformers/npu_model.py
+++ b/python/llm/src/ipex_llm/transformers/npu_model.py
@@ -302,8 +302,9 @@ class _BaseAutoModelClass:
         model.share_memory()
 
         if not pipeline:
-            if (not hasattr(model, 'llm') and
-                    model.config.model_type in ["qwen2", "llama", "minicpm"]):
+            # if (not hasattr(model, 'llm') and
+            #         model.config.model_type in ["qwen2", "llama", "minicpm"]):
+            if model.config.model_type in ["qwen2", "llama", "minicpm"]:
                 from ipex_llm.transformers.npu_models.convert import optimize_llm_single_process
                 optimize_llm_single_process(
                     llm,
@@ -313,7 +314,8 @@ class _BaseAutoModelClass:
                     group_size=quantization_group_size,
                     qtype=qtype,
                     save_directory=save_directory,
-                    fuse_layers=fuse_layers
+                    fuse_layers=fuse_layers,
+                    has_llm=hasattr(model, "llm")
                 )
             else:
                 optimize_llm(

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -527,7 +527,7 @@ def causal_lm_forward(
         input_length = len(input_list)
         if input_length > 1:
             logits = run_prefill_with_logits(self.model_ptr, input_list,
-                                            self.logits_buffer, self.vocab_size)
+                                             self.logits_buffer, self.vocab_size)
         else:
             logits = run_decode_with_logits(self.model_ptr, input_list[0],
                                             self.logits_buffer, self.vocab_size)

--- a/python/llm/src/ipex_llm/transformers/npu_models/convert.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/convert.py
@@ -528,21 +528,22 @@ def causal_lm_forward(
         if input_length > 1:
             logits = run_prefill_with_logits(self.model_ptr, input_list,
                                             self.logits_buffer, self.vocab_size)
-            logits = logits[:, :, :151666]
         else:
             logits = run_decode_with_logits(self.model_ptr, input_list[0],
                                             self.logits_buffer, self.vocab_size)
-            logits = logits[:, :, :151666]
     elif inputs_embeds is not None:
         seq_len = inputs_embeds.shape[1]
         pad_len = self.max_prompt_len - seq_len
-        inputs_embeds = torch.nn.functional.pad(inputs_embeds.to(torch.float16), (0, 0, 0, pad_len), value=0.0)
+        inputs_embeds = torch.nn.functional.pad(inputs_embeds.to(torch.float16),
+                                                (0, 0, 0, pad_len), value=0.0)
         logits = run_prefill_with_logits(self.model_ptr, None, self.logits_buffer,
                                          self.vocab_size, inputs_embeds, seq_len)
-        logits = logits[:, :, :151666]
     else:
-        invalidInputError(False, "Only need input_ids or inputs_embeds.")
+        invalidInputError(False, "Please specify either input_ids or inputs_embeds.")
 
+    if self.config.vocab_size == 151666:
+        # for MiniCPM-V 2.6
+        logits = logits[:, :, :151666]
 
     return CausalLMOutputWithPast(
         loss=None,

--- a/python/llm/src/ipex_llm/transformers/npu_models/npu_llm_cpp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/npu_llm_cpp.py
@@ -101,7 +101,7 @@ def run_prefill_with_logits(model_ptr, input_ids, logits, vocab_size,
         input_len = seq_len
     logits_ptr = logits.data.data_ptr()
     logits_ptr = ctypes.cast(logits_ptr, ctypes.POINTER(ctypes.c_float))
-    _lib.run_prefill_with_logits(model_ptr, input_ptr, input_len, logits_ptr, 
+    _lib.run_prefill_with_logits(model_ptr, input_ptr, input_len, logits_ptr,
                                  vocab_size, (input_ids is None))
     return logits
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/npu_llm_cpp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/npu_llm_cpp.py
@@ -90,7 +90,8 @@ def run_decode(model_ptr, input_id, vocab_size, repetition_penalty=1.0):
     return new_token
 
 
-def run_prefill_with_logits(model_ptr, input_ids, logits, vocab_size, inputs_embeds=None, seq_len=None):
+def run_prefill_with_logits(model_ptr, input_ids, logits, vocab_size,
+                            inputs_embeds=None, seq_len=None):
     if input_ids is not None:
         input_ptr = (ctypes.c_int32 * len(input_ids))(*input_ids)
         input_len = len(input_ids)
@@ -100,7 +101,8 @@ def run_prefill_with_logits(model_ptr, input_ids, logits, vocab_size, inputs_emb
         input_len = seq_len
     logits_ptr = logits.data.data_ptr()
     logits_ptr = ctypes.cast(logits_ptr, ctypes.POINTER(ctypes.c_float))
-    _lib.run_prefill_with_logits(model_ptr, input_ptr, input_len, logits_ptr, vocab_size, (input_ids is None))
+    _lib.run_prefill_with_logits(model_ptr, input_ptr, input_len, logits_ptr, 
+                                 vocab_size, (input_ids is None))
     return logits
 
 

--- a/python/llm/src/ipex_llm/transformers/npu_models/npu_llm_cpp.py
+++ b/python/llm/src/ipex_llm/transformers/npu_models/npu_llm_cpp.py
@@ -49,7 +49,7 @@ _lib.load_model_from_file.argtypes = [ctypes.c_char_p]
 _lib.load_model_from_file.restype = ctypes.c_void_p
 
 _lib.run_prefill.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int,
-                             ctypes.c_float]
+                             ctypes.c_float, ctypes.c_bool]
 _lib.run_prefill.restype = ctypes.POINTER(ctypes.c_float)
 
 _lib.run_decode.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_float]
@@ -62,7 +62,9 @@ _lib.reset.argtypes = [ctypes.c_void_p]
 _lib.reset.restype = None
 
 _lib.run_prefill_with_logits.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
-                                         ctypes.c_int, ctypes.POINTER(ctypes.c_float), ctypes.c_int]
+                                         ctypes.c_int, ctypes.POINTER(ctypes.c_float),
+                                         ctypes.c_int, ctypes.c_bool]
+
 _lib.run_prefill_with_logits.restype = None
 
 _lib.run_decode_with_logits.argtypes = [ctypes.c_void_p, ctypes.c_int,
@@ -77,7 +79,7 @@ def load_model_from_file(model_dir: str):
 def run_prefill(model_ptr, input_ids, vocab_size, repetition_penalty=1.0):
     input_ptr = (ctypes.c_int32 * len(input_ids))(*input_ids)
     input_len = len(input_ids)
-    plogits = _lib.run_prefill(model_ptr, input_ptr, input_len, repetition_penalty)
+    plogits = _lib.run_prefill(model_ptr, input_ptr, input_len, repetition_penalty, False)
     new_token = _lib.llm_sample_token(plogits, True, vocab_size)
     return new_token
 
@@ -88,19 +90,17 @@ def run_decode(model_ptr, input_id, vocab_size, repetition_penalty=1.0):
     return new_token
 
 
-def run_prefill_with_logits(model_ptr, input_ids, logits, vocab_size, inputs_embeds=None):
+def run_prefill_with_logits(model_ptr, input_ids, logits, vocab_size, inputs_embeds=None, seq_len=None):
     if input_ids is not None:
         input_ptr = (ctypes.c_int32 * len(input_ids))(*input_ids)
         input_len = len(input_ids)
     else:
         input_ptr = inputs_embeds.contiguous().data.data_ptr()
         input_ptr = ctypes.cast(input_ptr, ctypes.c_void_p)
-        uint16_ptr = ctypes.cast(input_ptr, ctypes.POINTER(ctypes.c_uint16))
-        print("[DEBUG INFO] Value pointed to by the pointer:", uint16_ptr.contents.value)
-        input_len = 0
+        input_len = seq_len
     logits_ptr = logits.data.data_ptr()
     logits_ptr = ctypes.cast(logits_ptr, ctypes.POINTER(ctypes.c_float))
-    _lib.run_prefill_with_logits(model_ptr, input_ptr, input_len, logits_ptr, vocab_size)
+    _lib.run_prefill_with_logits(model_ptr, input_ptr, input_len, logits_ptr, vocab_size, (input_ids is None))
     return logits
 
 

--- a/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
+++ b/python/llm/src/ipex_llm/transformers/npu_pipeline_model/qwen.py
@@ -34,6 +34,10 @@ def convert_lm_head_and_embedding(model, temp_dir, weight_dir,
     lm_head_n_splits = 1
     asym = getattr(model.config, "asym", False)
 
+    if vocab_size == 151666:
+        # for MiniCPM-V 2.6 lm_head on NPU
+        vocab_size = 152064
+
     if not isinstance(lm_head, SlicedLMHead):
         asym = lm_head.qtype == "asym_int4_rtn"
         if asym:


### PR DESCRIPTION
## Description

Work with https://github.com/intel-analytics/llm.cpp/pull/756 to support minicpm-v models with python cpp backend.


### 2. User API changes

N/A

### 3. Summary of the change 
- add necessary padding operations for lm_head of minicpm_v_2_6 to avoid compile error.
- update hf_generate related logic to be compatible with `inputs_embeds` as input
- update cpp functions

### 4. How to test?
- [x] Application test
Details: https://github.com/analytics-zoo/nano/issues/1800#issuecomment-2566185398